### PR TITLE
fix(istat): use /all/all?mode=available for constraints + slow-call warning

### DIFF
--- a/src/opensdmx/cli.py
+++ b/src/opensdmx/cli.py
@@ -429,6 +429,7 @@ def constraints(
 
     from . import load_dataset
     from .discovery import ConstraintsUnavailable, get_available_values, get_dimension_values
+    from .db_cache import get_cached_available_constraints
 
     try:
         with _status_ctx("[dim]Loading dataset...[/dim]"):
@@ -436,6 +437,13 @@ def constraints(
     except Exception as e:
         err_console.print(f"[red]Error:[/red] {e}")
         raise typer.Exit(1)
+
+    provider_cfg = get_provider()
+    if provider_cfg.get("agency_id") == "IT1" and get_cached_available_constraints(dataset_id) is None:
+        err_console.print(
+            "[yellow]⚠ ISTAT: first constraints call may take 30–120 s. "
+            "Results will be cached for 7 days.[/yellow]"
+        )
 
     try:
         with _status_ctx("[dim]Fetching constraints...[/dim]"):

--- a/src/opensdmx/discovery.py
+++ b/src/opensdmx/discovery.py
@@ -405,10 +405,11 @@ def get_available_values(dataset: dict) -> dict[str, pl.DataFrame]:
 
     provider = get_provider()
     constraint_endpoint = provider.get("constraint_endpoint", "availableconstraint")
+    constraint_suffix = provider.get("constraint_path_suffix", "")
     if constraint_endpoint == "contentconstraint":
         path = f"{constraint_endpoint}/{provider['agency_id']}/{df_id}"
     else:
-        path = f"{constraint_endpoint}/{df_id}"
+        path = f"{constraint_endpoint}/{df_id}{constraint_suffix}"
     try:
         constraint_params = provider.get("constraint_params", {"references": "none"})
         content = sdmx_request_xml(path, **constraint_params)

--- a/src/opensdmx/portals.json
+++ b/src/opensdmx/portals.json
@@ -34,6 +34,8 @@
     "agency_id": "IT1",
     "rate_limit": 13.0,
     "language": "it",
+    "constraint_path_suffix": "/all/all",
+    "constraint_params": {"mode": "available"},
     "constraints_supported": true,
     "last_n_supported": true
   },


### PR DESCRIPTION
## Summary

- **`portals.json`**: add `constraint_path_suffix: /all/all` and `constraint_params: {mode: available}` to the ISTAT provider. The `availableconstraint` endpoint is now called as `/availableconstraint/{id}/all/all?mode=available`, which returns only codes **actually present** in the dataflow (not the full theoretical codelist). This eliminates ambiguity where a codelist defines multiple "total" codes (e.g. both `T` and `9` for SEX) but only one exists in a given dataflow.
- **`discovery.py`**: apply `constraint_path_suffix` when building the endpoint path (generic, works for any future provider that needs it).
- **`cli.py`**: print a yellow warning before the first (slow) ISTAT constraints call; suppressed on cache hits (subsequent calls ~0.5 s).

## Test plan

- [ ] `opensdmx constraints 22_289 --provider istat` — first call shows warning, returns correct codes (SEX=9 only, not T)
- [ ] Second call completes in ~0.5 s (cache hit, no warning)
- [ ] `opensdmx constraints NAMA_10_GDP` (Eurostat) — unaffected, no warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)