### PR TITLE
fix: serialize HTTP calls per provider with flock

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "ollama>=0.6.1",
     "platformdirs>=4.9.4",
     "plotnine>=0.15.3",
+    "portalocker>=3.0.0",
     "polars>=1.38.1",
     "pyarrow>=23.0.1",
     "pyyaml>=6.0.3",

--- a/src/opensdmx/base.py
+++ b/src/opensdmx/base.py
@@ -7,6 +7,7 @@ import time
 from pathlib import Path
 
 import httpx
+import portalocker
 from tenacity import retry, stop_after_attempt, wait_exponential
 
 # Defaults for fields not specified in portals.json or custom providers
@@ -140,6 +141,18 @@ def _rate_limit_file() -> Path:
     return Path(tempfile.gettempdir()) / f"opensdmx_{key}_rate_limit.log"
 
 
+def _rate_limit_lock_file() -> Path:
+    """Return per-provider lock file.
+
+    Held for the entire HTTP call so that requests to the same provider are
+    strictly serialized across processes. Without this lock, two parallel
+    callers read the same timestamp, sleep the same amount, and fire HTTP
+    requests nearly simultaneously — defeating the rate limit.
+    """
+    key = _active_provider if isinstance(_active_provider, str) else get_agency_id() or "custom"
+    return Path(tempfile.gettempdir()) / f"opensdmx_{key}_rate_limit.lock"
+
+
 def _rate_limit_check() -> None:
     """Wait if needed to respect the provider's rate limit.
 
@@ -179,24 +192,30 @@ def sdmx_request(path: str, accept: str = "application/xml", **params) -> httpx.
 
     @retry(stop=stop_after_attempt(3), wait=wait_exponential(multiplier=0.5, min=0.5, max=4), reraise=True)
     def _do_request() -> httpx.Response:
-        _rate_limit_check()
-        # Record timestamp at request START (before HTTP call) so the interval
-        # is measured send-to-send, not receive-to-send.
-        try:
-            _rate_limit_file().write_text(str(time.time()))
-        except OSError:
-            pass
-        with httpx.Client(timeout=_timeout, follow_redirects=True) as client:
-            resp = client.get(
-                url,
-                params=params or None,
-                headers={
-                    "Accept": accept,
-                    "User-Agent": "opensdmx Python package",
-                },
-            )
-            resp.raise_for_status()
-            return resp
+        # Hold an exclusive file lock for the whole HTTP call. This serializes
+        # requests to the same provider across processes, so the rate limit is
+        # actually enforced instead of being defeated by parallel reads of the
+        # timestamp file. Lock is per-provider, so different providers stay
+        # parallel. If the process dies, the kernel releases the flock.
+        with portalocker.Lock(str(_rate_limit_lock_file()), flags=portalocker.LOCK_EX):
+            _rate_limit_check()
+            # Record timestamp at request START (before HTTP call) so the
+            # interval is measured send-to-send, not receive-to-send.
+            try:
+                _rate_limit_file().write_text(str(time.time()))
+            except OSError:
+                pass
+            with httpx.Client(timeout=_timeout, follow_redirects=True) as client:
+                resp = client.get(
+                    url,
+                    params=params or None,
+                    headers={
+                        "Accept": accept,
+                        "User-Agent": "opensdmx Python package",
+                    },
+                )
+                resp.raise_for_status()
+                return resp
 
     return _do_request()
 

--- a/src/opensdmx/portals.json
+++ b/src/opensdmx/portals.json
@@ -32,7 +32,7 @@
     "description": "Italian National Institute of Statistics. Covers population, economy, employment, prices and social indicators for Italy. Main source for Italian official statistics.",
     "base_url": "https://esploradati.istat.it/SDMXWS/rest",
     "agency_id": "IT1",
-    "rate_limit": 13.0,
+    "rate_limit": 15.0,
     "language": "it",
     "constraint_path_suffix": "/all/all",
     "constraint_params": {"mode": "available"},

--- a/uv.lock
+++ b/uv.lock
@@ -973,6 +973,7 @@ dependencies = [
     { name = "platformdirs" },
     { name = "plotnine" },
     { name = "polars" },
+    { name = "portalocker" },
     { name = "pyarrow" },
     { name = "pyyaml" },
     { name = "rich" },
@@ -1003,6 +1004,7 @@ requires-dist = [
     { name = "platformdirs", specifier = ">=4.9.4" },
     { name = "plotnine", specifier = ">=0.15.3" },
     { name = "polars", specifier = ">=1.38.1" },
+    { name = "portalocker", specifier = ">=3.0.0" },
     { name = "pyarrow", specifier = ">=23.0.1" },
     { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "questionary", marker = "extra == 'guide'", specifier = ">=2.1.1" },
@@ -1278,6 +1280,18 @@ wheels = [
 ]
 
 [[package]]
+name = "portalocker"
+version = "3.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/77/65b857a69ed876e1951e88aaba60f5ce6120c33703f7cb61a3c894b8c1b6/portalocker-3.2.0.tar.gz", hash = "sha256:1f3002956a54a8c3730586c5c77bf18fae4149e07eaf1c29fc3faf4d5a3f89ac", size = 95644, upload-time = "2025-06-14T13:20:40.03Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/a6/38c8e2f318bf67d338f4d629e93b0b4b9af331f455f0390ea8ce4a099b26/portalocker-3.2.0-py3-none-any.whl", hash = "sha256:3cdc5f565312224bc570c49337bd21428bba0ef363bbcf58b9ef4a9f11779968", size = 22424, upload-time = "2025-06-14T13:20:38.083Z" },
+]
+
+[[package]]
 name = "prompt-toolkit"
 version = "3.0.52"
 source = { registry = "https://pypi.org/simple" }
@@ -1492,6 +1506,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "pywin32"
+version = "311"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/ab/01ea1943d4eba0f850c3c61e78e8dd59757ff815ff3ccd0a84de5f541f42/pywin32-311-cp312-cp312-win32.whl", hash = "sha256:750ec6e621af2b948540032557b10a2d43b0cee2ae9758c54154d711cc852d31", size = 8706543, upload-time = "2025-07-14T20:13:20.765Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/a8/a0e8d07d4d051ec7502cd58b291ec98dcc0c3fff027caad0470b72cfcc2f/pywin32-311-cp312-cp312-win_amd64.whl", hash = "sha256:b8c095edad5c211ff31c05223658e71bf7116daa0ecf3ad85f3201ea3190d067", size = 9495040, upload-time = "2025-07-14T20:13:22.543Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/3a/2ae996277b4b50f17d61f0603efd8253cb2d79cc7ae159468007b586396d/pywin32-311-cp312-cp312-win_arm64.whl", hash = "sha256:e286f46a9a39c4a18b319c28f59b61de793654af2f395c102b4f819e584b5852", size = 8710102, upload-time = "2025-07-14T20:13:24.682Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/be/3fd5de0979fcb3994bfee0d65ed8ca9506a8a1260651b86174f6a86f52b3/pywin32-311-cp313-cp313-win32.whl", hash = "sha256:f95ba5a847cba10dd8c4d8fefa9f2a6cf283b8b88ed6178fa8a6c1ab16054d0d", size = 8705700, upload-time = "2025-07-14T20:13:26.471Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/28/e0a1909523c6890208295a29e05c2adb2126364e289826c0a8bc7297bd5c/pywin32-311-cp313-cp313-win_amd64.whl", hash = "sha256:718a38f7e5b058e76aee1c56ddd06908116d35147e133427e59a3983f703a20d", size = 9494700, upload-time = "2025-07-14T20:13:28.243Z" },
+    { url = "https://files.pythonhosted.org/packages/04/bf/90339ac0f55726dce7d794e6d79a18a91265bdf3aa70b6b9ca52f35e022a/pywin32-311-cp313-cp313-win_arm64.whl", hash = "sha256:7b4075d959648406202d92a2310cb990fea19b535c7f4a78d3f5e10b926eeb8a", size = 8709318, upload-time = "2025-07-14T20:13:30.348Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/31/097f2e132c4f16d99a22bfb777e0fd88bd8e1c634304e102f313af69ace5/pywin32-311-cp314-cp314-win32.whl", hash = "sha256:b7a2c10b93f8986666d0c803ee19b5990885872a7de910fc460f9b0c2fbf92ee", size = 8840714, upload-time = "2025-07-14T20:13:32.449Z" },
+    { url = "https://files.pythonhosted.org/packages/90/4b/07c77d8ba0e01349358082713400435347df8426208171ce297da32c313d/pywin32-311-cp314-cp314-win_amd64.whl", hash = "sha256:3aca44c046bd2ed8c90de9cb8427f581c479e594e99b5c0bb19b29c10fd6cb87", size = 9656800, upload-time = "2025-07-14T20:13:34.312Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/d2/21af5c535501a7233e734b8af901574572da66fcc254cb35d0609c9080dd/pywin32-311-cp314-cp314-win_arm64.whl", hash = "sha256:a508e2d9025764a8270f93111a970e1d0fbfc33f4153b388bb649b7eec4f9b42", size = 8932540, upload-time = "2025-07-14T20:13:36.379Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Wrap each HTTP request with `portalocker.Lock` on a per-provider lock file, so the rate limit holds across concurrent processes (the previous timestamp-file approach raced when multiple processes read it before any wrote).
- Add `portalocker>=3.0.0` dependency.
- Bump ISTAT rate_limit 13s → 15s for a safer margin.

## Test plan
- [x] `tmp/test_race.py` with 4 parallel workers on Eurostat (rate_limit 0.5s): PASS, min gap 0.62s, total 2.66s.
- [ ] Smoke: normal single-process CLI calls still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)