### PR TITLE
fix: follow-up PR #11 Copilot review (cache key + per-user lock dir)

### DIFF
--- a/LOG.md
+++ b/LOG.md
@@ -2,6 +2,9 @@
 
 ## 2026-04-15
 
+- fix: move rate-limit lock and timestamp files from the shared system tempdir to the per-user cache base (via `platformdirs`), avoiding cross-user interference on multi-tenant hosts; cross-OS by construction
+- fix: derive provider cache/lock key from base URL hash when custom provider has no `agency_id`, so two such providers don't share the same lock and get serialized together
+- test: cover cross-process flock — assert `portalocker.Lock` is called with the per-provider lock path
 - chore: bump version to v0.3.32
 - fix: serialize HTTP calls per provider with `portalocker` flock, so the rate limit holds across concurrent processes (parallel timestamp-file readers could previously defeat it)
 - chore: bump ISTAT rate_limit 13s → 15s for a safer margin

--- a/src/opensdmx/base.py
+++ b/src/opensdmx/base.py
@@ -1,5 +1,6 @@
 """Core HTTP client and provider configuration for SDMX 2.1 REST APIs."""
 
+import hashlib
 import json
 import sys
 import tempfile
@@ -117,10 +118,26 @@ def _resolve_cache_base() -> Path:
     return fallback
 
 
+def _provider_cache_key() -> str:
+    """Stable per-provider key for cache, rate-limit and lock files.
+
+    For a preset provider the key is the preset name. For a custom URL
+    provider it is the agency_id when set, otherwise an 8-char sha256 of
+    the base URL — so two custom providers with different URLs don't share
+    the same cache/lock and get serialized together.
+    """
+    if isinstance(_active_provider, str):
+        return _active_provider
+    agency = get_agency_id()
+    if agency:
+        return agency
+    base = _active_provider.get("base_url", "")
+    return "custom_" + hashlib.sha256(base.encode("utf-8")).hexdigest()[:8]
+
+
 def get_cache_dir() -> Path:
     """Return cache directory for the active provider."""
-    cache_key = _active_provider if isinstance(_active_provider, str) else get_agency_id() or "custom"
-    cache_dir = _resolve_cache_base() / cache_key
+    cache_dir = _resolve_cache_base() / _provider_cache_key()
     cache_dir.mkdir(parents=True, exist_ok=True)
     return cache_dir
 
@@ -135,10 +152,21 @@ def set_timeout(seconds: float | None = None) -> float:
     return old
 
 
+def _rate_limit_dir() -> Path:
+    """Return the per-user directory for rate-limit state files.
+
+    Sits under the per-user cache base (same root as the data cache), so
+    lock and timestamp files are isolated per user and not exposed in the
+    world-writable system temp dir.
+    """
+    d = _resolve_cache_base() / "rate_limit"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
 def _rate_limit_file() -> Path:
-    """Return per-provider rate limit temp file."""
-    key = _active_provider if isinstance(_active_provider, str) else get_agency_id() or "custom"
-    return Path(tempfile.gettempdir()) / f"opensdmx_{key}_rate_limit.log"
+    """Return per-provider rate limit timestamp file."""
+    return _rate_limit_dir() / f"{_provider_cache_key()}.log"
 
 
 def _rate_limit_lock_file() -> Path:
@@ -149,8 +177,7 @@ def _rate_limit_lock_file() -> Path:
     callers read the same timestamp, sleep the same amount, and fire HTTP
     requests nearly simultaneously — defeating the rate limit.
     """
-    key = _active_provider if isinstance(_active_provider, str) else get_agency_id() or "custom"
-    return Path(tempfile.gettempdir()) / f"opensdmx_{key}_rate_limit.lock"
+    return _rate_limit_dir() / f"{_provider_cache_key()}.lock"
 
 
 def _rate_limit_check() -> None:

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -7,7 +7,13 @@ from unittest.mock import MagicMock, patch
 import polars as pl
 import pytest
 
-from opensdmx.base import sdmx_request_csv, set_provider
+from opensdmx.base import (
+    _provider_cache_key,
+    _rate_limit_lock_file,
+    sdmx_request,
+    sdmx_request_csv,
+    set_provider,
+)
 from opensdmx.discovery import all_available
 from opensdmx.retrieval import get_data
 
@@ -76,6 +82,44 @@ class TestSdmxRequestCsv:
         with _mock_http_client(_CSV_CONTENT):
             df = sdmx_request_csv("data/UNE_RT_M")
         assert df["TIME_PERIOD"].dtype == pl.Utf8
+
+
+# ---------------------------------------------------------------------------
+# Cross-process serialization via portalocker.Lock
+# ---------------------------------------------------------------------------
+
+class TestRateLimitLock:
+    def test_portalocker_invoked_with_provider_lock_path(self):
+        """Every HTTP call must acquire the per-provider flock."""
+        set_provider("eurostat")
+        expected_path = str(_rate_limit_lock_file())
+
+        lock_cm = MagicMock()
+        lock_cm.__enter__ = MagicMock(return_value=lock_cm)
+        lock_cm.__exit__ = MagicMock(return_value=False)
+
+        with (
+            _mock_http_client(_CSV_CONTENT),
+            patch("opensdmx.base.portalocker.Lock", return_value=lock_cm) as mock_lock,
+        ):
+            sdmx_request("data/UNE_RT_M", accept="text/csv")
+
+        assert mock_lock.called
+        called_path = mock_lock.call_args.args[0]
+        assert called_path == expected_path
+        assert "eurostat" in called_path
+
+    def test_custom_provider_blank_agency_gets_url_hash_key(self):
+        """Custom URL providers without agency_id must not share the 'custom' key."""
+        set_provider("https://example.org/sdmx")
+        key_a = _provider_cache_key()
+
+        set_provider("https://other.example.net/api")
+        key_b = _provider_cache_key()
+
+        assert key_a != key_b
+        assert key_a.startswith("custom_")
+        assert key_b.startswith("custom_")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Follow-up on Copilot review comments on PR #11. All three comments addressed.

- **Custom provider isolation** — `_provider_cache_key()` derives a stable key from the base URL sha256 when a custom URL provider has no `agency_id`. Previously all such providers shared the key `"custom"` and were serialized together.
- **Lock/timestamp files out of /tmp** — moved to `_resolve_cache_base()/rate_limit/` (per-user via `platformdirs`). Avoids cross-user interference on multi-tenant hosts and world-writable tempdir exposure. Cross-OS by construction (XDG on Linux, `~/Library/Caches` on macOS, `%LOCALAPPDATA%` on Windows).
- **Test coverage for flock** — new `TestRateLimitLock` asserts `portalocker.Lock` is invoked with the per-provider lock path, and that two custom URL providers without `agency_id` get distinct cache keys.

## Test plan

- [x] `uv run pytest` — 89/89 pass
- [x] Manual verification: `opensdmx get` still works end-to-end (tested against ISTAT laureati + popolazione comunale)

🤖 Generated with [Claude Code](https://claude.com/claude-code)