### PR TITLE
feat: thematic category tree (tree, siblings, search --category)

### DIFF
--- a/LOG.md
+++ b/LOG.md
@@ -1,5 +1,14 @@
 # LOG
 
+## 2026-04-19
+
+- feat: add thematic category tree (SDMX categoryscheme + categorisation) via new `opensdmx tree` command (ASCII in table mode, flat JSON/CSV otherwise); `--scheme` renders tree, `--depth` limits nesting
+- feat: add `--category` filter to `opensdmx search` (leaf id or dotted path); matches dataflow through categorisation
+- feat: add `opensdmx siblings <df_id>` — shows dataflow siblings in each category (one group per membership); surfaces related variants that text search misses
+- feat: new `src/opensdmx/categories.py` with two-parquet cache (`categories.parquet`, `categorisation.parquet`), lazy fetch on first `tree` call, 7-day TTL via `CATEGORIES_CACHE_TTL`, stale-df warning to stderr
+- feat: add `categories_supported` flag to `portals.json` (true: eurostat, istat, ecb, oecd, insee, abs, bis; false: comext, bundesbank, worldbank, imf) + new column in `opensdmx providers`
+- chore: add read-only MCP tool allowlist to `.claude/settings.local.json` (mempalace search/get/list, playwright network/snapshot/screenshot, chrome-devtools network tools)
+
 ## 2026-04-15
 
 - chore: bump version to v0.3.34

--- a/README.md
+++ b/README.md
@@ -189,6 +189,9 @@ All commands accept `--provider` (`-p`) to select the provider.
 | `opensdmx info <id> [-p provider]` | Show dataset metadata and dimensions |
 | `opensdmx values <id> <dim> [--grep pattern] [-p provider]` | Show codelist values for a dimension (case-insensitive); optionally filter by regex |
 | `opensdmx constraints <id> [dim] [--grep pattern] [-p provider]` | Show values actually present in the dataflow (via `availableconstraint`); optionally filter by regex |
+| `opensdmx tree [--scheme ID] [--depth N] [-p provider]` | Browse the thematic tree (SDMX `categoryscheme` + `categorisation`); ASCII tree in table mode, flat rows in JSON/CSV |
+| `opensdmx siblings <id> [-p provider]` | Show dataflow siblings in each category — discover related variants that text search misses |
+| `opensdmx search <keyword> --category <CAT> [-p provider]` | Restrict search to a category (leaf id or dotted path); cuts false positives vs pure token match |
 | `opensdmx get <id> [--DIM VALUE] [--start-period P] [--end-period P] [--last-n N] [--first-n N] [--out file] [--query-file file.yaml] [-p provider]` | Download data; optionally save the query as YAML |
 | `opensdmx run <query.yaml> [--out file] [-p provider]` | Re-run a query saved with `--query-file` |
 | `opensdmx plot <id\|file.csv> [--DIM VALUE] [--geom line\|bar\|barh\|point\|scatter] [--out file] [-p provider]` | Plot data as chart |
@@ -214,7 +217,18 @@ opensdmx search "disoccupazione" --provider istat
 opensdmx get 151_929 --provider istat --FREQ A --REF_AREA IT --out data.csv
 opensdmx search "GDP" --provider oecd
 opensdmx search "inflation" --provider ecb
+
+# Thematic tree (categoryscheme + categorisation)
+opensdmx tree --provider istat                       # list thematic schemes
+opensdmx tree --scheme Z1000AGR --provider istat     # browse ISTAT Agricoltura
+opensdmx search "prezzi" --category DCSP_PREZZIAGR --provider istat
+opensdmx siblings NAMA_10_GDP                        # 27 Eurostat GDP-related dataflows
+opensdmx siblings 104_466_DF_DCSP_FERTILIZZANTI_2 --provider istat  # all 7 fertilizer variants
 ```
+
+Not every provider exposes the thematic tree. Run `opensdmx providers` and check
+the `categories` column (✓/✗). Currently supported: `eurostat`, `istat`, `ecb`,
+`oecd`, `insee`, `abs`, `bis`.
 
 ### Query files
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "opensdmx"
-version = "0.3.34"
+version = "0.4.0"
 description = "Simple Python interface to any SDMX 2.1 REST API (Eurostat, ISTAT, and more)"
 readme = "README.md"
 authors = [

--- a/skills/sdmx-explorer/SKILL.md
+++ b/skills/sdmx-explorer/SKILL.md
@@ -92,6 +92,54 @@ Before searching, parse the user's question on two levels:
    Example: *"unemployment for EU countries, by age group and sex"* →
    topic keywords: `unemployment`; expected dimensions: `age`, `sex`, `geo`.
 
+### Step 1a+ (optional) — Narrow the search thematically with `opensdmx tree`
+
+Before a full-text `search`, consider the thematic tree. Some providers expose
+a hierarchical catalog (SDMX `categoryscheme` + `categorisation`) that groups
+dataflows by topic — turns a flat list of thousands of dataflows into a
+navigable tree.
+
+Supported providers (check with `opensdmx providers` — `categories` column):
+- ✓ `eurostat`, `istat`, `ecb`, `oecd`, `insee`, `abs`, `bis`
+- ✗ `comext`, `bundesbank`, `worldbank`, `imf` (no category endpoint) — skip tree, go straight to `search`.
+
+When to use `tree`:
+
+- The user question targets a well-defined **domain** (agriculture, education,
+  health, trade, prices, population, …) where many dataflows share a root
+  theme. Browsing the tree is faster than scanning hundreds of keyword hits.
+- The keyword is generic or ambiguous (e.g. "impresa", "energia") and would
+  return too many results.
+- The user explicitly asks to "explore what's available on X".
+
+When to skip `tree` and go straight to `search`:
+
+- The user already gives a precise dataflow id or a narrow term with a clear
+  acronym (e.g. `NAMA_10_GDP`, `LFSA_ERGAN`).
+- The provider does not support it (see above).
+
+Workflow:
+
+```bash
+# 1. List all thematic schemes for the provider (one row per top-level domain)
+opensdmx tree --provider istat
+
+# 2. Enter the relevant scheme — render the category sub-tree
+opensdmx tree --scheme Z1000AGR --provider istat
+
+# 3. When you spot a relevant category, filter search to it
+opensdmx search "prezzi" --category DCSP_PREZZIAGR --provider istat
+```
+
+The `--category` filter accepts either a leaf id (`DCSP_LATTE`) or a full
+dotted path (`AGR_CRP.DCSP_LATTE`). It reduces false positives compared to
+pure token matching (e.g. finds `AGR_R_ACCTS` under Agriculture even when
+the description does not contain the word "agriculture").
+
+Note: the first `tree` invocation per provider triggers a one-time fetch
+(can take ~1 minute on Eurostat due to the 24 MB categorisation response),
+then the result is cached for 7 days under the provider's cache directory.
+
 ### Step 1b — Search and pre-filter candidates
 
 Search for dataflows:
@@ -182,6 +230,43 @@ describe more precisely what you need.
 ```
 
 Wait for the user's choice before proceeding.
+
+### Step 1d (optional) — Explore siblings of a candidate
+
+Once you have a candidate dataflow, check its **siblings** — other dataflows in
+the same thematic category. This often reveals variants (regional vs national,
+annual vs quarterly, different units of measure) that pure text search misses
+because the candidate's siblings do not share its exact wording.
+
+```bash
+opensdmx siblings <dataflow_id> --provider <p>
+```
+
+Only works on providers with `categories_supported: true`. A dataflow may
+belong to multiple categories: the command returns one group per membership.
+
+When to use:
+
+- The candidate's title sounds specific ("Fertilizers distributed for biological
+  agriculture"); you want to know if a broader version exists.
+- You expect a series at a different granularity (prov/reg/nat) that may not
+  share keywords.
+- The dataset list is fragmented across many small dataflow ids sharing a
+  common prefix — the category view clusters them.
+
+Example — starting from a single result, discover 6 complementary siblings:
+
+```bash
+$ opensdmx siblings 104_466_DF_DCSP_FERTILIZZANTI_2 --provider istat
+
+Agricoltura > Fertilizzanti  (7 siblings)
+  → 104_466_DF_DCSP_FERTILIZZANTI_2   uso in agricoltura biologica
+    104_466_DF_DCSP_FERTILIZZANTI_1   stato liquido o solido
+    104_466_DF_DCSP_FERTILIZZANTI_3   area di produzione
+    104_466_DF_DCSP_FERTILIZZANTI_4   distribuiti - prov.
+    104_466_DF_DCSP_FERTILIZZANTI_5   elementi nutritivi - prov.
+    ...
+```
 
 ---
 

--- a/src/opensdmx/cache_config.py
+++ b/src/opensdmx/cache_config.py
@@ -18,3 +18,8 @@ METADATA_CACHE_TTL: float = float(
 CONSTRAINTS_CACHE_TTL: float = float(
     os.environ.get("OPENSDMX_CONSTRAINTS_CACHE_TTL", 604_800)
 )
+
+# Thematic category tree (parquet files) — default 7 days
+CATEGORIES_CACHE_TTL: float = float(
+    os.environ.get("OPENSDMX_CATEGORIES_CACHE_TTL", 604_800)
+)

--- a/src/opensdmx/categories.py
+++ b/src/opensdmx/categories.py
@@ -1,0 +1,301 @@
+"""Thematic category tree support (SDMX categoryscheme + categorisation)."""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+import time
+from pathlib import Path
+
+import polars as pl
+
+from .base import get_cache_dir, get_provider, sdmx_request_xml
+from .cache_config import CATEGORIES_CACHE_TTL
+from .utils import xml_attr_safe, xml_parse
+
+logger = logging.getLogger(__name__)
+
+
+class CategoriesNotSupported(Exception):
+    """Raised when the active provider does not expose /categoryscheme."""
+
+
+CATEGORIES_SCHEMA = {
+    "scheme_id": pl.Utf8,
+    "scheme_name": pl.Utf8,
+    "cat_id": pl.Utf8,
+    "cat_path": pl.Utf8,
+    "cat_name": pl.Utf8,
+    "parent_path": pl.Utf8,
+    "depth": pl.Int32,
+}
+
+CATEGORISATION_SCHEMA = {
+    "df_id": pl.Utf8,
+    "scheme_id": pl.Utf8,
+    "cat_path": pl.Utf8,
+}
+
+
+def _struct_path(endpoint: str) -> str:
+    prefix = get_provider().get("metadata_prefix", "")
+    return f"{prefix}/{endpoint}" if prefix else endpoint
+
+
+def _categories_cache_path() -> Path:
+    return get_cache_dir() / "categories.parquet"
+
+
+def _categorisation_cache_path() -> Path:
+    return get_cache_dir() / "categorisation.parquet"
+
+
+def _load_cached() -> tuple[pl.DataFrame, pl.DataFrame] | None:
+    cp = _categories_cache_path()
+    zp = _categorisation_cache_path()
+    if not (cp.exists() and zp.exists()):
+        return None
+    age = time.time() - min(cp.stat().st_mtime, zp.stat().st_mtime)
+    if age >= CATEGORIES_CACHE_TTL:
+        return None
+    return pl.read_parquet(cp), pl.read_parquet(zp)
+
+
+def _direct_name(elem, language: str, ns: dict) -> str:
+    """Return the Name element (direct child) for the given language.
+
+    Falls back to any direct-child Name if preferred language is missing.
+    We do NOT search descendants — that would pick up child categories' names.
+    """
+    common_ns = ns.get("common", "")
+    tag = f"{{{common_ns}}}Name" if common_ns else "Name"
+    direct_names = [n for n in elem.findall(tag)]
+    for n in direct_names:
+        if n.get("{http://www.w3.org/XML/1998/namespace}lang") == language:
+            return (n.text or "").strip()
+    if direct_names:
+        return (direct_names[0].text or "").strip()
+    return ""
+
+
+def _walk_categories(parent_elem, scheme_id, scheme_name, parent_path, depth, language, ns, rows):
+    struct_ns = ns.get("structure", "")
+    tag = f"{{{struct_ns}}}Category" if struct_ns else "Category"
+    for cat in parent_elem.findall(tag):
+        cid = xml_attr_safe(cat, "id")
+        if not cid:
+            continue
+        cat_path = f"{parent_path}.{cid}" if parent_path else cid
+        rows.append({
+            "scheme_id": scheme_id,
+            "scheme_name": scheme_name,
+            "cat_id": cid,
+            "cat_path": cat_path,
+            "cat_name": _direct_name(cat, language, ns),
+            "parent_path": parent_path,
+            "depth": depth,
+        })
+        _walk_categories(cat, scheme_id, scheme_name, cat_path, depth + 1, language, ns, rows)
+
+
+def _fetch_categoryscheme() -> pl.DataFrame:
+    """Fetch and parse /categoryscheme into a flat DataFrame."""
+    provider = get_provider()
+    catalog_agency = provider.get("catalog_agency", provider["agency_id"])
+    language = provider.get("language", "en")
+    path = _struct_path(f"categoryscheme/{catalog_agency}/ALL/latest")
+    content = sdmx_request_xml(path)
+    root, ns = xml_parse(content)
+    struct_ns = ns.get("structure", "")
+
+    rows: list[dict] = []
+    scheme_tag = f"{{{struct_ns}}}CategoryScheme" if struct_ns else "CategoryScheme"
+    for scheme in root.iter(scheme_tag):
+        sid = xml_attr_safe(scheme, "id")
+        if not sid:
+            continue
+        sname = _direct_name(scheme, language, ns)
+        _walk_categories(scheme, sid, sname, "", 1, language, ns, rows)
+
+    return pl.DataFrame(rows, schema=CATEGORIES_SCHEMA)
+
+
+def _fetch_categorisation() -> pl.DataFrame:
+    """Fetch and parse /categorisation into df_id -> (scheme_id, cat_path)."""
+    provider = get_provider()
+    catalog_agency = provider.get("catalog_agency", provider["agency_id"])
+    path = _struct_path(f"categorisation/{catalog_agency}/ALL/latest")
+    content = sdmx_request_xml(path)
+    root, ns = xml_parse(content)
+    struct_ns = ns.get("structure", "")
+
+    rows: list[dict] = []
+    cz_tag = f"{{{struct_ns}}}Categorisation" if struct_ns else "Categorisation"
+    src_tag = f"{{{struct_ns}}}Source" if struct_ns else "Source"
+    tgt_tag = f"{{{struct_ns}}}Target" if struct_ns else "Target"
+    for cz in root.iter(cz_tag):
+        src = cz.find(f"{src_tag}/Ref")
+        tgt = cz.find(f"{tgt_tag}/Ref")
+        if src is None or tgt is None:
+            continue
+        if src.get("class") and src.get("class") != "Dataflow":
+            continue
+        df_id = src.get("id")
+        scheme_id = tgt.get("maintainableParentID")
+        cat_path = tgt.get("id")
+        if not (df_id and scheme_id and cat_path):
+            continue
+        rows.append({
+            "df_id": df_id,
+            "scheme_id": scheme_id,
+            "cat_path": cat_path,
+        })
+
+    return pl.DataFrame(rows, schema=CATEGORISATION_SCHEMA)
+
+
+def supported_providers() -> list[str]:
+    """Return list of provider aliases with categories_supported=true in portals.json."""
+    portals_path = Path(__file__).parent / "portals.json"
+    with open(portals_path) as f:
+        portals = json.load(f)
+    return [k for k, v in portals.items() if v.get("categories_supported")]
+
+
+def load_categories() -> tuple[pl.DataFrame, pl.DataFrame]:
+    """Return (categories_df, categorisation_df) for the active provider.
+
+    First call fetches from the SDMX endpoints and caches two parquet files.
+    Subsequent calls read from cache until TTL expires.
+
+    Raises:
+        CategoriesNotSupported: provider does not expose /categoryscheme.
+    """
+    provider = get_provider()
+    if not provider.get("categories_supported", False):
+        supported = supported_providers()
+        raise CategoriesNotSupported(
+            "Active provider does not expose /categoryscheme. "
+            f"Providers with category tree: {', '.join(supported) or '(none)'}"
+        )
+
+    cached = _load_cached()
+    if cached is not None:
+        return cached
+
+    print(
+        "[dim]Building thematic cache from categoryscheme + categorisation "
+        "(first run can take 1-2 minutes)...[/dim]",
+        file=sys.stderr,
+    )
+
+    categories_df = _fetch_categoryscheme()
+    categorisation_df = _fetch_categorisation()
+
+    _warn_stale(categorisation_df)
+
+    try:
+        categories_df.write_parquet(_categories_cache_path())
+        categorisation_df.write_parquet(_categorisation_cache_path())
+    except OSError as e:
+        logger.warning(f"Could not write categories cache: {e}")
+
+    return categories_df, categorisation_df
+
+
+def _warn_stale(categorisation_df: pl.DataFrame) -> None:
+    """Log a single aggregated warning if some df_ids in categorisation are stale."""
+    try:
+        from .discovery import all_available
+        valid = set(all_available()["df_id"].to_list())
+    except Exception as e:
+        logger.warning(f"Could not cross-check stale dataflows: {e}")
+        return
+
+    if categorisation_df.is_empty():
+        return
+    total = len(categorisation_df)
+    stale = categorisation_df.filter(~pl.col("df_id").is_in(list(valid)))
+    n_stale = len(stale)
+    if n_stale:
+        logger.warning(
+            f"{n_stale}/{total} dataflow in categorisation not found in dataflows list (stale entries)"
+        )
+
+
+def siblings_of(df_id: str) -> list[dict]:
+    """Return all dataflow siblings grouped by category.
+
+    A dataflow can belong to multiple categories (cross-listed). This function
+    returns one group per (scheme_id, cat_path) membership, each group
+    containing the dataflows sharing that category.
+
+    Each returned group has keys:
+        scheme_id, scheme_name, cat_path, cat_name, siblings (list of dict).
+    Each sibling has: df_id, df_description, is_target (bool).
+
+    Returns empty list if the dataflow is not categorized or the provider
+    does not expose categories.
+    """
+    categories_df, categorisation_df = load_categories()
+    memberships = categorisation_df.filter(pl.col("df_id") == df_id)
+    if memberships.is_empty():
+        return []
+
+    from .discovery import all_available
+    dataflows = all_available().select(["df_id", "df_description"])
+
+    groups = []
+    for row in memberships.iter_rows(named=True):
+        scheme_id = row["scheme_id"]
+        cat_path = row["cat_path"]
+        cat_info = categories_df.filter(
+            (pl.col("scheme_id") == scheme_id) & (pl.col("cat_path") == cat_path)
+        )
+        cat_name = cat_info.select("cat_name").row(0)[0] if not cat_info.is_empty() else ""
+        scheme_name = cat_info.select("scheme_name").row(0)[0] if not cat_info.is_empty() else ""
+
+        sib_ids = categorisation_df.filter(
+            (pl.col("scheme_id") == scheme_id) & (pl.col("cat_path") == cat_path)
+        ).select("df_id")
+        sibs = sib_ids.join(dataflows, on="df_id", how="inner").unique(subset=["df_id"])
+
+        siblings = [
+            {
+                "df_id": r["df_id"],
+                "df_description": r["df_description"] or "",
+                "is_target": r["df_id"] == df_id,
+            }
+            for r in sibs.sort("df_id").iter_rows(named=True)
+        ]
+        groups.append({
+            "scheme_id": scheme_id,
+            "scheme_name": scheme_name,
+            "cat_path": cat_path,
+            "cat_name": cat_name,
+            "siblings": siblings,
+        })
+    return groups
+
+
+def filter_by_category(cat_id_or_path: str) -> pl.DataFrame:
+    """Return dataflows belonging to a category (exact path or leaf id).
+
+    Matches any cat_path that ends with the given token. Returns the
+    dataflows DataFrame enriched with cat_path + scheme_id.
+    """
+    _, categorisation_df = load_categories()
+    if categorisation_df.is_empty():
+        return categorisation_df
+
+    needle = cat_id_or_path
+    mask = (
+        (pl.col("cat_path") == needle)
+        | pl.col("cat_path").str.ends_with(f".{needle}")
+    )
+    matched = categorisation_df.filter(mask)
+
+    from .discovery import all_available
+    dataflows = all_available()
+    return dataflows.join(matched, on="df_id", how="inner")

--- a/src/opensdmx/categories.py
+++ b/src/opensdmx/categories.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 import logging
-import sys
 import time
 from pathlib import Path
 
@@ -124,7 +123,8 @@ def _fetch_categoryscheme() -> pl.DataFrame:
 def _fetch_categorisation() -> pl.DataFrame:
     """Fetch and parse /categorisation into df_id -> (scheme_id, cat_path)."""
     provider = get_provider()
-    catalog_agency = provider.get("catalog_agency", provider["agency_id"])
+    agency_id = provider["agency_id"]
+    catalog_agency = provider.get("catalog_agency", agency_id)
     path = _struct_path(f"categorisation/{catalog_agency}/ALL/latest")
     content = sdmx_request_xml(path)
     root, ns = xml_parse(content)
@@ -142,6 +142,12 @@ def _fetch_categorisation() -> pl.DataFrame:
         if src.get("class") and src.get("class") != "Dataflow":
             continue
         df_id = src.get("id")
+        src_agency = src.get("agencyID")
+        # Mirror discovery.all_available(): if provider uses a cross-agency
+        # catalog, prefix df_id with the source agency so categorisation rows
+        # match the dataflow list (otherwise siblings/filter return empty).
+        if df_id and src_agency and catalog_agency != agency_id:
+            df_id = f"{src_agency},{df_id}"
         scheme_id = tgt.get("maintainableParentID")
         cat_path = tgt.get("id")
         if not (df_id and scheme_id and cat_path):
@@ -184,10 +190,9 @@ def load_categories() -> tuple[pl.DataFrame, pl.DataFrame]:
     if cached is not None:
         return cached
 
-    print(
-        "[dim]Building thematic cache from categoryscheme + categorisation "
-        "(first run can take 1-2 minutes)...[/dim]",
-        file=sys.stderr,
+    logger.info(
+        "Building thematic cache from categoryscheme + categorisation "
+        "(first run can take 1-2 minutes)..."
     )
 
     categories_df = _fetch_categoryscheme()
@@ -220,7 +225,7 @@ def _warn_stale(categorisation_df: pl.DataFrame) -> None:
     n_stale = len(stale)
     if n_stale:
         logger.warning(
-            f"{n_stale}/{total} dataflow in categorisation not found in dataflows list (stale entries)"
+            f"{n_stale}/{total} entries in categorisation not found in dataflows list (stale entries)"
         )
 
 
@@ -244,7 +249,13 @@ def siblings_of(df_id: str) -> list[dict]:
         return []
 
     from .discovery import all_available
-    dataflows = all_available().select(["df_id", "df_description"])
+    try:
+        dataflows = all_available().select(["df_id", "df_description"])
+    except Exception as e:
+        logger.warning(f"Could not load dataflow list for descriptions: {e}")
+        dataflows = pl.DataFrame(
+            schema={"df_id": pl.Utf8, "df_description": pl.Utf8}
+        )
 
     groups = []
     for row in memberships.iter_rows(named=True):
@@ -258,8 +269,12 @@ def siblings_of(df_id: str) -> list[dict]:
 
         sib_ids = categorisation_df.filter(
             (pl.col("scheme_id") == scheme_id) & (pl.col("cat_path") == cat_path)
-        ).select("df_id")
-        sibs = sib_ids.join(dataflows, on="df_id", how="inner").unique(subset=["df_id"])
+        ).select("df_id").unique()
+        # Left-join so the sibling list survives when the dataflows table is
+        # unavailable (e.g. provider-side error on the /dataflow endpoint).
+        sibs = sib_ids.join(dataflows, on="df_id", how="left").with_columns(
+            pl.col("df_description").fill_null("")
+        )
 
         siblings = [
             {
@@ -297,5 +312,9 @@ def filter_by_category(cat_id_or_path: str) -> pl.DataFrame:
     matched = categorisation_df.filter(mask)
 
     from .discovery import all_available
-    dataflows = all_available()
+    try:
+        dataflows = all_available()
+    except Exception as e:
+        logger.warning(f"Could not load dataflow list: {e}; returning category ids only")
+        return matched
     return dataflows.join(matched, on="df_id", how="inner")

--- a/src/opensdmx/cli.py
+++ b/src/opensdmx/cli.py
@@ -147,6 +147,7 @@ def search(
     n: int = typer.Option(50, "--n", help="Results per page (default: 50). Combine with --page to paginate."),
     page: int = typer.Option(1, "--page", help="Page number, 1-based (default: 1). Use with --n to paginate. Title shows range e.g. '21-40 of 114'."),
     all_results: bool = typer.Option(False, "--all", help="Show ALL results from cache, ignoring --n and --page."),
+    category: Optional[str] = typer.Option(None, "--category", "-c", help="Restrict search to a category (leaf id or dotted path). Provider must support categories. See `opensdmx tree`."),
     provider: Optional[str] = typer.Option(None, "--provider", "-p", help=_PROVIDER_HELP),
 ):
     """Search datasets by keyword in the local cache (or semantically with --semantic).
@@ -212,8 +213,26 @@ def search(
         err_console.print(f"[red]Error:[/red] {e}")
         raise typer.Exit(1)
 
+    if category:
+        import polars as pl
+
+        from .categories import CategoriesNotSupported, filter_by_category
+        try:
+            cat_df = filter_by_category(category)
+        except CategoriesNotSupported as e:
+            err_console.print(f"[red]Error:[/red] {e}")
+            raise typer.Exit(1)
+        if cat_df.is_empty():
+            err_console.print(f"[yellow]No dataflow found for category:[/yellow] {category}")
+            raise typer.Exit(0)
+        allowed = set(cat_df["df_id"].to_list())
+        df = df.filter(pl.col("df_id").is_in(list(allowed)))
+
     if df.is_empty():
-        err_console.print(f"[yellow]No datasets found for:[/yellow] {keyword}")
+        msg = f"No datasets found for: {keyword}"
+        if category:
+            msg += f" (category={category})"
+        err_console.print(f"[yellow]{msg}[/yellow]")
         raise typer.Exit(0)
 
     total = len(df)
@@ -596,6 +615,7 @@ def providers():
                 "agency_id": cfg.get("agency_id", ""),
                 "constraints_supported": cfg.get("constraints_supported"),
                 "last_n_supported": cfg.get("last_n_supported"),
+                "categories_supported": cfg.get("categories_supported"),
             }
             for alias, cfg in PROVIDERS.items()
         ]
@@ -615,6 +635,7 @@ def providers():
     table.add_column("agency", style="dim", no_wrap=True)
     table.add_column("constraints", justify="center", no_wrap=True)
     table.add_column("last_n", justify="center", no_wrap=True)
+    table.add_column("categories", justify="center", no_wrap=True)
 
     for alias, cfg in PROVIDERS.items():
         table.add_row(
@@ -624,9 +645,188 @@ def providers():
             cfg.get("agency_id", ""),
             _cap(cfg, "constraints_supported"),
             _cap(cfg, "last_n_supported"),
+            _cap(cfg, "categories_supported"),
         )
 
     console.print(table)
+
+
+@app.command()
+def tree(
+    scheme: Optional[str] = typer.Option(None, "--scheme", "-s", help="Render the tree for a specific scheme_id. If omitted, lists all schemes with dataflow counts."),
+    depth: Optional[int] = typer.Option(None, "--depth", "-d", help="Limit tree nesting depth (1 = only top-level)."),
+    provider: Optional[str] = typer.Option(None, "--provider", "-p", help=_PROVIDER_HELP),
+):
+    """Browse the thematic tree of dataflows (categoryscheme + categorisation).
+
+    Without --scheme: lists all schemes with their dataflow counts.
+    With --scheme: renders an ASCII tree of that scheme's categories.
+
+    Not all providers expose categories. Use `opensdmx providers` to check.
+    In table mode output is an ASCII tree; in -o json|csv a flat table.
+
+    Examples:
+
+      opensdmx tree --provider istat
+      opensdmx tree --scheme Z1000AGR --provider istat
+      opensdmx tree --scheme Z1000AGR --depth 2 --provider istat
+      opensdmx tree --scheme t_economy --provider eurostat
+    """
+    _apply_provider(provider)
+
+    from .categories import CategoriesNotSupported, load_categories
+
+    try:
+        with _status_ctx("[dim]Loading category tree...[/dim]"):
+            categories_df, categorisation_df = load_categories()
+    except CategoriesNotSupported as e:
+        err_console.print(f"[red]Error:[/red] {e}")
+        raise typer.Exit(1)
+
+    if categories_df.is_empty():
+        err_console.print("[yellow]No categories returned by the provider.[/yellow]")
+        raise typer.Exit(0)
+
+    import polars as pl
+
+    df_counts = (
+        categorisation_df.group_by(["scheme_id", "cat_path"])
+        .agg(pl.len().alias("n_df"))
+    )
+
+    if scheme is None:
+        scheme_counts = (
+            categorisation_df.group_by("scheme_id")
+            .agg(pl.len().alias("n_df"))
+        )
+        schemes = (
+            categories_df.select(["scheme_id", "scheme_name"])
+            .unique()
+            .join(scheme_counts, on="scheme_id", how="left")
+            .with_columns(pl.col("n_df").fill_null(0))
+            .sort("scheme_id")
+        )
+
+        if _output_mode != "table":
+            rows = [
+                {"scheme_id": r["scheme_id"], "scheme_name": r["scheme_name"] or "", "n_df": int(r["n_df"])}
+                for r in schemes.iter_rows(named=True)
+            ]
+            _emit(rows, df=schemes)
+            return
+
+        table = Table(title="Category schemes", show_lines=False)
+        table.add_column("scheme_id", style="cyan", no_wrap=True)
+        table.add_column("scheme_name")
+        table.add_column("n_df", justify="right")
+        for r in schemes.iter_rows(named=True):
+            table.add_row(r["scheme_id"], r["scheme_name"] or "", str(r["n_df"]))
+        console.print(table)
+        return
+
+    scheme_rows = categories_df.filter(pl.col("scheme_id") == scheme)
+    if scheme_rows.is_empty():
+        err_console.print(f"[red]Error:[/red] scheme not found: {scheme}")
+        raise typer.Exit(1)
+
+    if depth is not None:
+        scheme_rows = scheme_rows.filter(pl.col("depth") <= depth)
+
+    scheme_rows = scheme_rows.join(df_counts, on=["scheme_id", "cat_path"], how="left").with_columns(
+        pl.col("n_df").fill_null(0)
+    )
+
+    if _output_mode != "table":
+        rows = [
+            {
+                "scheme_id": r["scheme_id"],
+                "cat_id": r["cat_id"],
+                "cat_path": r["cat_path"],
+                "cat_name": r["cat_name"] or "",
+                "parent_path": r["parent_path"] or "",
+                "depth": int(r["depth"]),
+                "n_df": int(r["n_df"]),
+            }
+            for r in scheme_rows.iter_rows(named=True)
+        ]
+        _emit(rows, df=scheme_rows)
+        return
+
+    scheme_name = scheme_rows.select("scheme_name").row(0)[0] or scheme
+    console.print(f"[bold]{scheme_name}[/bold] [dim]({scheme})[/dim]")
+
+    children: dict[str, list[dict]] = {}
+    for r in scheme_rows.iter_rows(named=True):
+        children.setdefault(r["parent_path"] or "", []).append(r)
+    for kids in children.values():
+        kids.sort(key=lambda x: x["cat_name"] or x["cat_id"])
+
+    def render(parent_path: str, prefix: str) -> None:
+        kids = children.get(parent_path, [])
+        for i, node in enumerate(kids):
+            last = (i == len(kids) - 1)
+            branch = "└── " if last else "├── "
+            count_str = f" [dim]({node['n_df']} df)[/dim]" if node["n_df"] else ""
+            label = node["cat_name"] or node["cat_id"]
+            console.print(f"{prefix}{branch}{label} [dim][{node['cat_id']}][/dim]{count_str}")
+            next_prefix = prefix + ("    " if last else "│   ")
+            render(node["cat_path"], next_prefix)
+
+    render("", "")
+
+
+@app.command()
+def siblings(
+    dataset_id: str = typer.Argument(..., help="Dataflow ID to locate in the thematic tree"),
+    provider: Optional[str] = typer.Option(None, "--provider", "-p", help=_PROVIDER_HELP),
+):
+    """Show dataflow siblings — other dataflows in the same category.
+
+    Given a dataflow ID, look up its categories and list all dataflows
+    sharing each category. Useful to discover related datasets that a pure
+    text search would miss (e.g. "Fertilizzanti" contains 7 dataflow variants
+    but only 1 contains the word "agricoltura" in its description).
+
+    A dataflow can belong to multiple categories: one group per membership.
+
+    Examples:
+
+      opensdmx siblings 104_466_DF_DCSP_FERTILIZZANTI_2 --provider istat
+      opensdmx siblings NAMA_10_GDP --provider eurostat
+    """
+    _apply_provider(provider)
+
+    from .categories import CategoriesNotSupported, siblings_of
+
+    try:
+        with _status_ctx("[dim]Loading category tree...[/dim]"):
+            groups = siblings_of(dataset_id)
+    except CategoriesNotSupported as e:
+        err_console.print(f"[red]Error:[/red] {e}")
+        raise typer.Exit(1)
+
+    if not groups:
+        err_console.print(
+            f"[yellow]Dataflow {dataset_id} is not categorized (or not found).[/yellow]"
+        )
+        raise typer.Exit(0)
+
+    if _output_mode != "table":
+        _emit(groups)
+        return
+
+    for g in groups:
+        header = f"{g['scheme_name']} > {g['cat_name'] or g['cat_path']}"
+        subtitle = f"scheme={g['scheme_id']}  cat_path={g['cat_path']}  siblings={len(g['siblings'])}"
+        console.print(f"\n[bold]{header}[/bold]  [dim]({subtitle})[/dim]")
+        table = Table(show_lines=False)
+        table.add_column("", style="green", no_wrap=True)
+        table.add_column("df_id", style="cyan", no_wrap=True)
+        table.add_column("df_description")
+        for s in g["siblings"]:
+            marker = "→" if s["is_target"] else ""
+            table.add_row(marker, s["df_id"], s["df_description"])
+        console.print(table)
 
 
 _LARGE_DATASET_THRESHOLD = 5000

--- a/src/opensdmx/cli.py
+++ b/src/opensdmx/cli.py
@@ -691,13 +691,13 @@ def tree(
 
     df_counts = (
         categorisation_df.group_by(["scheme_id", "cat_path"])
-        .agg(pl.len().alias("n_df"))
+        .agg(pl.col("df_id").n_unique().alias("n_df"))
     )
 
     if scheme is None:
         scheme_counts = (
             categorisation_df.group_by("scheme_id")
-            .agg(pl.len().alias("n_df"))
+            .agg(pl.col("df_id").n_unique().alias("n_df"))
         )
         schemes = (
             categories_df.select(["scheme_id", "scheme_name"])

--- a/src/opensdmx/cli.py
+++ b/src/opensdmx/cli.py
@@ -225,8 +225,7 @@ def search(
         if cat_df.is_empty():
             err_console.print(f"[yellow]No dataflow found for category:[/yellow] {category}")
             raise typer.Exit(0)
-        allowed = set(cat_df["df_id"].to_list())
-        df = df.filter(pl.col("df_id").is_in(list(allowed)))
+        df = df.filter(pl.col("df_id").is_in(cat_df["df_id"].unique()))
 
     if df.is_empty():
         msg = f"No datasets found for: {keyword}"

--- a/src/opensdmx/portals.json
+++ b/src/opensdmx/portals.json
@@ -12,7 +12,8 @@
     "data_format_param": "SDMX-CSV",
     "dataflow_page_url": "https://ec.europa.eu/eurostat/databrowser/product/page/{dataflow_id}",
     "constraints_supported": true,
-    "last_n_supported": true
+    "last_n_supported": true,
+    "categories_supported": true
   },
   "comext": {
     "name": "Eurostat Comext",
@@ -25,7 +26,8 @@
     "datastructure_agency": "ESTAT",
     "data_format_param": "SDMX-CSV",
     "constraints_supported": false,
-    "last_n_supported": true
+    "last_n_supported": true,
+    "categories_supported": false
   },
   "istat": {
     "name": "ISTAT",
@@ -37,7 +39,8 @@
     "constraint_path_suffix": "/all/all",
     "constraint_params": {"mode": "available"},
     "constraints_supported": true,
-    "last_n_supported": true
+    "last_n_supported": true,
+    "categories_supported": true
   },
   "ecb": {
     "name": "European Central Bank",
@@ -45,7 +48,8 @@
     "base_url": "https://data-api.ecb.europa.eu/service",
     "agency_id": "ECB",
     "constraints_supported": false,
-    "last_n_supported": true
+    "last_n_supported": true,
+    "categories_supported": true
   },
   "oecd": {
     "name": "OECD",
@@ -55,7 +59,8 @@
     "catalog_agency": "all",
     "constraint_params": {},
     "constraints_supported": false,
-    "last_n_supported": true
+    "last_n_supported": true,
+    "categories_supported": true
   },
   "insee": {
     "name": "INSEE",
@@ -63,7 +68,8 @@
     "base_url": "https://www.bdm.insee.fr/series/sdmx",
     "agency_id": "FR1",
     "constraints_supported": false,
-    "last_n_supported": true
+    "last_n_supported": true,
+    "categories_supported": true
   },
   "bundesbank": {
     "name": "Deutsche Bundesbank",
@@ -73,7 +79,8 @@
     "metadata_prefix": "metadata",
     "datastructure_agency": "BBK",
     "constraints_supported": false,
-    "last_n_supported": true
+    "last_n_supported": true,
+    "categories_supported": false
   },
   "worldbank": {
     "name": "World Bank",
@@ -84,7 +91,8 @@
     "data_path_suffix": "/",
     "unsupported_params": ["lastNObservations", "firstNObservations"],
     "constraints_supported": false,
-    "last_n_supported": false
+    "last_n_supported": false,
+    "categories_supported": false
   },
   "abs": {
     "name": "Australian Bureau of Statistics",
@@ -92,7 +100,8 @@
     "base_url": "https://data.api.abs.gov.au/rest",
     "agency_id": "ABS",
     "constraints_supported": true,
-    "last_n_supported": true
+    "last_n_supported": true,
+    "categories_supported": true
   },
   "bis": {
     "name": "Bank for International Settlements",
@@ -100,7 +109,8 @@
     "base_url": "https://stats.bis.org/api/v1",
     "agency_id": "BIS",
     "constraints_supported": true,
-    "last_n_supported": true
+    "last_n_supported": true,
+    "categories_supported": true
   },
   "imf": {
     "name": "International Monetary Fund",
@@ -109,6 +119,7 @@
     "agency_id": "IMF.RES",
     "catalog_agency": "all",
     "constraints_supported": true,
-    "last_n_supported": true
+    "last_n_supported": true,
+    "categories_supported": false
   }
 }

--- a/tests/test_categories.py
+++ b/tests/test_categories.py
@@ -175,6 +175,71 @@ def test_fetch_categorisation_maps_dataflow_to_category(monkeypatch):
     assert wheat["cat_path"] == "CROPS.CEREALS"
 
 
+def test_fetch_categorisation_prefixes_df_id_when_catalog_agency_differs(monkeypatch):
+    """OECD-like providers (catalog_agency != agency_id) need df_id prefixed
+    with the source agencyID to join with all_available() dataflow ids."""
+    xml = b"""\
+<message:Structure xmlns:message="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/message"
+                   xmlns:structure="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/structure"
+                   xmlns:common="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/common">
+  <message:Structures>
+    <structure:Categorisations>
+      <structure:Categorisation id="CAT_WHEAT">
+        <structure:Source>
+          <Ref id="WHEAT" agencyID="OECD" class="Dataflow"/>
+        </structure:Source>
+        <structure:Target>
+          <Ref id="CEREALS" maintainableParentID="AGRI"/>
+        </structure:Target>
+      </structure:Categorisation>
+    </structure:Categorisations>
+  </message:Structures>
+</message:Structure>
+"""
+    monkeypatch.setattr(categories, "sdmx_request_xml", lambda path, **kw: xml)
+    monkeypatch.setattr(
+        categories,
+        "get_provider",
+        lambda: {"agency_id": "IT1", "catalog_agency": "all"},
+    )
+    df = _fetch_categorisation()
+    assert len(df) == 1
+    row = df.row(0, named=True)
+    assert row["df_id"] == "OECD,WHEAT"
+    assert row["scheme_id"] == "AGRI"
+    assert row["cat_path"] == "CEREALS"
+
+
+def test_fetch_categorisation_no_prefix_when_catalog_agency_matches(monkeypatch):
+    """When catalog_agency == agency_id, df_id stays unprefixed."""
+    xml = b"""\
+<message:Structure xmlns:message="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/message"
+                   xmlns:structure="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/structure"
+                   xmlns:common="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/common">
+  <message:Structures>
+    <structure:Categorisations>
+      <structure:Categorisation id="CAT_WHEAT">
+        <structure:Source>
+          <Ref id="WHEAT" agencyID="IT1" class="Dataflow"/>
+        </structure:Source>
+        <structure:Target>
+          <Ref id="CEREALS" maintainableParentID="AGRI"/>
+        </structure:Target>
+      </structure:Categorisation>
+    </structure:Categorisations>
+  </message:Structures>
+</message:Structure>
+"""
+    monkeypatch.setattr(categories, "sdmx_request_xml", lambda path, **kw: xml)
+    monkeypatch.setattr(
+        categories,
+        "get_provider",
+        lambda: {"agency_id": "IT1"},
+    )
+    df = _fetch_categorisation()
+    assert df.row(0, named=True)["df_id"] == "WHEAT"
+
+
 # ── supported_providers ──────────────────────────────────────────────
 
 def test_supported_providers_reads_portals_json():

--- a/tests/test_categories.py
+++ b/tests/test_categories.py
@@ -1,0 +1,295 @@
+"""Tests for opensdmx.categories – thematic tree parsing and siblings."""
+
+from __future__ import annotations
+
+import polars as pl
+import pytest
+
+from opensdmx import categories
+from opensdmx.categories import (
+    CategoriesNotSupported,
+    _direct_name,
+    _fetch_categorisation,
+    _fetch_categoryscheme,
+    filter_by_category,
+    siblings_of,
+    supported_providers,
+)
+from opensdmx.utils import xml_parse
+
+
+# ── fixtures ─────────────────────────────────────────────────────────
+
+CATEGORYSCHEME_XML = b"""\
+<message:Structure xmlns:message="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/message"
+                   xmlns:structure="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/structure"
+                   xmlns:common="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/common"
+                   xmlns:xml="http://www.w3.org/XML/1998/namespace">
+  <message:Structures>
+    <structure:CategorySchemes>
+      <structure:CategoryScheme id="AGRI" agencyID="IT1" version="1.0">
+        <common:Name xml:lang="it">Agricoltura</common:Name>
+        <common:Name xml:lang="en">Agriculture</common:Name>
+        <structure:Category id="CROPS">
+          <common:Name xml:lang="it">Coltivazioni</common:Name>
+          <common:Name xml:lang="en">Crops</common:Name>
+          <structure:Category id="CEREALS">
+            <common:Name xml:lang="it">Cereali</common:Name>
+            <common:Name xml:lang="en">Cereals</common:Name>
+          </structure:Category>
+        </structure:Category>
+        <structure:Category id="LIVESTOCK">
+          <common:Name xml:lang="it">Allevamenti</common:Name>
+        </structure:Category>
+      </structure:CategoryScheme>
+    </structure:CategorySchemes>
+  </message:Structures>
+</message:Structure>
+"""
+
+
+CATEGORISATION_XML = b"""\
+<message:Structure xmlns:message="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/message"
+                   xmlns:structure="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/structure"
+                   xmlns:common="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/common">
+  <message:Structures>
+    <structure:Categorisations>
+      <structure:Categorisation id="CZ_WHEAT_CROPS">
+        <structure:Source>
+          <Ref id="WHEAT" class="Dataflow"/>
+        </structure:Source>
+        <structure:Target>
+          <Ref id="CROPS.CEREALS" maintainableParentID="AGRI" class="Category"/>
+        </structure:Target>
+      </structure:Categorisation>
+      <structure:Categorisation id="CZ_RICE_CROPS">
+        <structure:Source>
+          <Ref id="RICE" class="Dataflow"/>
+        </structure:Source>
+        <structure:Target>
+          <Ref id="CROPS.CEREALS" maintainableParentID="AGRI" class="Category"/>
+        </structure:Target>
+      </structure:Categorisation>
+      <structure:Categorisation id="CZ_COWS_LIVESTOCK">
+        <structure:Source>
+          <Ref id="COWS" class="Dataflow"/>
+        </structure:Source>
+        <structure:Target>
+          <Ref id="LIVESTOCK" maintainableParentID="AGRI" class="Category"/>
+        </structure:Target>
+      </structure:Categorisation>
+      <structure:Categorisation id="CZ_NONDF_IGNORED">
+        <structure:Source>
+          <Ref id="X" class="Codelist"/>
+        </structure:Source>
+        <structure:Target>
+          <Ref id="LIVESTOCK" maintainableParentID="AGRI" class="Category"/>
+        </structure:Target>
+      </structure:Categorisation>
+    </structure:Categorisations>
+  </message:Structures>
+</message:Structure>
+"""
+
+
+# ── _direct_name ─────────────────────────────────────────────────────
+
+def test_direct_name_picks_requested_language():
+    root, ns = xml_parse(CATEGORYSCHEME_XML)
+    struct_ns = ns["structure"]
+    scheme = root.find(f".//{{{struct_ns}}}CategoryScheme")
+    assert _direct_name(scheme, "it", ns) == "Agricoltura"
+    assert _direct_name(scheme, "en", ns) == "Agriculture"
+
+
+def test_direct_name_falls_back_to_first_available():
+    root, ns = xml_parse(CATEGORYSCHEME_XML)
+    struct_ns = ns["structure"]
+    # LIVESTOCK has only Italian Name; English request falls back
+    livestock = root.find(f".//{{{struct_ns}}}Category[@id='LIVESTOCK']")
+    assert _direct_name(livestock, "en", ns) == "Allevamenti"
+
+
+def test_direct_name_does_not_capture_children_names():
+    """Guard: lookup must be a direct child, not descendant."""
+    root, ns = xml_parse(CATEGORYSCHEME_XML)
+    struct_ns = ns["structure"]
+    crops = root.find(f".//{{{struct_ns}}}Category[@id='CROPS']")
+    # CROPS has nested CEREALS with its own Name; _direct_name must return CROPS' name
+    assert _direct_name(crops, "it", ns) == "Coltivazioni"
+
+
+# ── _fetch_categoryscheme (via monkeypatched sdmx_request_xml) ───────
+
+def test_fetch_categoryscheme_builds_flat_rows(monkeypatch):
+    monkeypatch.setattr(categories, "sdmx_request_xml", lambda path, **kw: CATEGORYSCHEME_XML)
+    monkeypatch.setattr(
+        categories,
+        "get_provider",
+        lambda: {"agency_id": "IT1", "language": "it"},
+    )
+    df = _fetch_categoryscheme()
+    assert len(df) == 3  # CROPS, CROPS.CEREALS, LIVESTOCK
+    rows = {r["cat_path"]: r for r in df.iter_rows(named=True)}
+
+    assert set(rows) == {"CROPS", "CROPS.CEREALS", "LIVESTOCK"}
+    assert rows["CROPS"]["scheme_name"] == "Agricoltura"
+    assert rows["CROPS"]["cat_name"] == "Coltivazioni"
+    assert rows["CROPS"]["parent_path"] == ""
+    assert rows["CROPS"]["depth"] == 1
+    assert rows["CROPS.CEREALS"]["parent_path"] == "CROPS"
+    assert rows["CROPS.CEREALS"]["depth"] == 2
+
+
+def test_fetch_categoryscheme_language_fallback(monkeypatch):
+    monkeypatch.setattr(categories, "sdmx_request_xml", lambda path, **kw: CATEGORYSCHEME_XML)
+    monkeypatch.setattr(
+        categories,
+        "get_provider",
+        lambda: {"agency_id": "IT1", "language": "en"},
+    )
+    df = _fetch_categoryscheme()
+    rows = {r["cat_path"]: r for r in df.iter_rows(named=True)}
+    # LIVESTOCK has only Italian — fallback keeps IT when EN missing
+    assert rows["LIVESTOCK"]["cat_name"] == "Allevamenti"
+    # CROPS has both — uses EN
+    assert rows["CROPS"]["cat_name"] == "Crops"
+
+
+# ── _fetch_categorisation ────────────────────────────────────────────
+
+def test_fetch_categorisation_maps_dataflow_to_category(monkeypatch):
+    monkeypatch.setattr(categories, "sdmx_request_xml", lambda path, **kw: CATEGORISATION_XML)
+    monkeypatch.setattr(
+        categories,
+        "get_provider",
+        lambda: {"agency_id": "IT1"},
+    )
+    df = _fetch_categorisation()
+    # 3 dataflow sources; the codelist source (class="Codelist") is skipped
+    assert len(df) == 3
+    ids = set(df["df_id"].to_list())
+    assert ids == {"WHEAT", "RICE", "COWS"}
+    wheat = df.filter(pl.col("df_id") == "WHEAT").row(0, named=True)
+    assert wheat["scheme_id"] == "AGRI"
+    assert wheat["cat_path"] == "CROPS.CEREALS"
+
+
+# ── supported_providers ──────────────────────────────────────────────
+
+def test_supported_providers_reads_portals_json():
+    supported = supported_providers()
+    assert "istat" in supported
+    assert "eurostat" in supported
+    # These are marked unsupported
+    assert "imf" not in supported
+    assert "worldbank" not in supported
+
+
+# ── siblings_of (via monkeypatched load_categories + all_available) ──
+
+@pytest.fixture
+def sample_cache(monkeypatch):
+    """Inject in-memory DataFrames for load_categories() and all_available()."""
+    cats_df = pl.DataFrame(
+        [
+            {"scheme_id": "AGRI", "scheme_name": "Agricoltura",
+             "cat_id": "CROPS", "cat_path": "CROPS", "cat_name": "Coltivazioni",
+             "parent_path": "", "depth": 1},
+            {"scheme_id": "AGRI", "scheme_name": "Agricoltura",
+             "cat_id": "CEREALS", "cat_path": "CROPS.CEREALS", "cat_name": "Cereali",
+             "parent_path": "CROPS", "depth": 2},
+            {"scheme_id": "AGRI", "scheme_name": "Agricoltura",
+             "cat_id": "LIVESTOCK", "cat_path": "LIVESTOCK", "cat_name": "Allevamenti",
+             "parent_path": "", "depth": 1},
+        ],
+        schema=categories.CATEGORIES_SCHEMA,
+    )
+    cz_df = pl.DataFrame(
+        [
+            {"df_id": "WHEAT", "scheme_id": "AGRI", "cat_path": "CROPS.CEREALS"},
+            {"df_id": "RICE", "scheme_id": "AGRI", "cat_path": "CROPS.CEREALS"},
+            {"df_id": "OATS", "scheme_id": "AGRI", "cat_path": "CROPS.CEREALS"},
+            {"df_id": "COWS", "scheme_id": "AGRI", "cat_path": "LIVESTOCK"},
+            # WHEAT also cross-listed in LIVESTOCK (multi-membership)
+            {"df_id": "WHEAT", "scheme_id": "AGRI", "cat_path": "LIVESTOCK"},
+        ],
+        schema=categories.CATEGORISATION_SCHEMA,
+    )
+    dataflows_df = pl.DataFrame(
+        [
+            {"df_id": "WHEAT", "df_description": "Wheat production"},
+            {"df_id": "RICE", "df_description": "Rice harvest"},
+            {"df_id": "OATS", "df_description": "Oats yield"},
+            {"df_id": "COWS", "df_description": "Cattle census"},
+        ],
+        schema={"df_id": pl.Utf8, "df_description": pl.Utf8},
+    )
+    monkeypatch.setattr(categories, "load_categories", lambda: (cats_df, cz_df))
+
+    import opensdmx.discovery as discovery_mod
+    monkeypatch.setattr(discovery_mod, "all_available", lambda: dataflows_df)
+    return cats_df, cz_df, dataflows_df
+
+
+def test_siblings_of_single_category(sample_cache):
+    groups = siblings_of("RICE")
+    assert len(groups) == 1
+    g = groups[0]
+    assert g["cat_path"] == "CROPS.CEREALS"
+    assert g["cat_name"] == "Cereali"
+    assert g["scheme_name"] == "Agricoltura"
+    assert len(g["siblings"]) == 3
+    target = next(s for s in g["siblings"] if s["is_target"])
+    assert target["df_id"] == "RICE"
+    others = {s["df_id"] for s in g["siblings"] if not s["is_target"]}
+    assert others == {"WHEAT", "OATS"}
+
+
+def test_siblings_of_multi_membership(sample_cache):
+    """WHEAT is in both CROPS.CEREALS and LIVESTOCK → two groups."""
+    groups = siblings_of("WHEAT")
+    assert len(groups) == 2
+    paths = sorted(g["cat_path"] for g in groups)
+    assert paths == ["CROPS.CEREALS", "LIVESTOCK"]
+    livestock = next(g for g in groups if g["cat_path"] == "LIVESTOCK")
+    ids = {s["df_id"] for s in livestock["siblings"]}
+    assert ids == {"WHEAT", "COWS"}
+
+
+def test_siblings_of_unknown_returns_empty(sample_cache):
+    assert siblings_of("DOES_NOT_EXIST") == []
+
+
+# ── filter_by_category ───────────────────────────────────────────────
+
+def test_filter_by_category_exact_path(sample_cache):
+    df = filter_by_category("CROPS.CEREALS")
+    assert len(df) == 3
+    assert set(df["df_id"].to_list()) == {"WHEAT", "RICE", "OATS"}
+
+
+def test_filter_by_category_leaf_id(sample_cache):
+    """Match by trailing segment: `CEREALS` resolves to CROPS.CEREALS."""
+    df = filter_by_category("CEREALS")
+    assert len(df) == 3
+    assert set(df["df_id"].to_list()) == {"WHEAT", "RICE", "OATS"}
+
+
+def test_filter_by_category_no_match(sample_cache):
+    df = filter_by_category("NOPE")
+    assert df.is_empty()
+
+
+# ── CategoriesNotSupported ───────────────────────────────────────────
+
+def test_load_categories_raises_when_unsupported(monkeypatch):
+    monkeypatch.setattr(
+        categories,
+        "get_provider",
+        lambda: {"agency_id": "TEST", "categories_supported": False},
+    )
+    with pytest.raises(CategoriesNotSupported) as excinfo:
+        categories.load_categories()
+    # Hint must list at least one of the supported providers
+    assert "istat" in str(excinfo.value) or "eurostat" in str(excinfo.value)

--- a/uv.lock
+++ b/uv.lock
@@ -963,7 +963,7 @@ wheels = [
 
 [[package]]
 name = "opensdmx"
-version = "0.3.34"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

Wraps SDMX `/categoryscheme` + `/categorisation` endpoints into three new CLI commands that turn a flat list of thousands of dataflows into a navigable thematic tree.

- `opensdmx tree [--scheme] [--depth]` — browse schemes/categories (ASCII tree in table mode, flat JSON/CSV otherwise)
- `opensdmx siblings <df_id>` — list dataflows sharing each category membership; surfaces variants that text search misses
- `opensdmx search --category <id>` — restrict search to a category, cutting false positives vs pure token match

## Why

Text search misses dataflows whose descriptions don't share keywords with the query. Concrete cases verified live:

- **`search "agricoltura" --provider istat`** → 9 hits; 1 fertilizer variant  
  **`siblings 104_466_DF_DCSP_FERTILIZZANTI_2`** → 7 complementary fertilizer dataflows (liquido/solido, biologico, area, prov, elementi nutritivi). 6 of the 7 are invisible to a pure keyword search.

- **`siblings NAMA_10_GDP --provider eurostat`** → 27 GDP-related dataflows including `TEC00001`, `SDG_08_10`, `TIPSEN10`, `TET00003/04` — cryptic ids that no text search on "gdp" would group together.

## Provider support

Probed all 11 built-in providers:

- ✓ supported: `eurostat`, `istat`, `ecb`, `oecd`, `insee`, `abs`, `bis`
- ✗ not supported: `comext` (empty `<CategorySchemes/>`), `bundesbank` (404), `worldbank` (redirect→403), `imf` (204)

New `categories_supported` flag in `portals.json` + column in `opensdmx providers`. Unsupported providers fail with exit 1 and a hint listing the supported ones.

## Caching

Mirrors `dataflows.parquet` strategy:

- Two parquet files: `categories.parquet` + `categorisation.parquet`
- Lazy fetch on first `tree` call per provider
- 7-day TTL via `CATEGORIES_CACHE_TTL` (env override `OPENSDMX_CATEGORIES_CACHE_TTL`)
- Stale-df warning to stderr when categorisation references ids not in the dataflow list (e.g. 75/11221 on Eurostat = 0.7%, 6/5015 on ISTAT)

First fetch cost on the biggest provider (Eurostat): ~75s for 24 MB categorisation; thereafter served from the 49 + 94 KB parquet cache.

## Skill update

`skills/sdmx-explorer/SKILL.md` gains two optional workflow steps:

- Step 1a+ — narrow thematically with `tree` before running `search`
- Step 1d — explore siblings after picking a candidate

## Version

Minor bump `0.3.34 → 0.4.0` — new public CLI API.

## Test plan

- [x] 103/103 pytest (89 existing + 14 new in `tests/test_categories.py`)
- [x] Live smoke test on all 7 supported providers (eurostat, istat, ecb, oecd, insee, abs, bis)
- [x] Error paths verified: unsupported provider → exit 1; unknown df → empty groups; multi-category membership → one group per category
- [ ] Reviewer: sanity-check the rendered tree on any non-ISTAT/Eurostat provider you use (ECB, OECD, ABS etc.)
- [ ] Reviewer: on OECD, `tree` emits a stale cross-check warning because `all_available()` on OECD returns non-XML in this environment; the warning is cosmetic (feature works), but worth a follow-up issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)