### PR TITLE
fix: force SDMX 2.1 Accept header — unblocks OECD

### DIFF
--- a/LOG.md
+++ b/LOG.md
@@ -2,6 +2,7 @@
 
 ## 2026-04-19
 
+- fix: use SDMX 2.1 structure Accept header in `sdmx_request_xml`; fixes OECD returning JSON on `/dataflow` (closes #15); unblocks `all_available`/`search` on OECD and fills `df_description` in `siblings` output
 - feat: add thematic category tree (SDMX categoryscheme + categorisation) via new `opensdmx tree` command (ASCII in table mode, flat JSON/CSV otherwise); `--scheme` renders tree, `--depth` limits nesting
 - feat: add `--category` filter to `opensdmx search` (leaf id or dotted path); matches dataflow through categorisation
 - feat: add `opensdmx siblings <df_id>` — shows dataflow siblings in each category (one group per membership); surfaces related variants that text search misses

--- a/src/opensdmx/base.py
+++ b/src/opensdmx/base.py
@@ -257,8 +257,16 @@ def sdmx_request(path: str, accept: str = "application/xml", **params) -> httpx.
 
 
 def sdmx_request_xml(path: str, **params):
-    """Make a request and return the raw XML bytes."""
-    resp = sdmx_request(path, accept="application/xml", **params)
+    """Make a request and return the raw XML bytes.
+
+    Uses the SDMX 2.1 structure Accept header — the generic "application/xml"
+    is not honoured by some providers (e.g. OECD) which then default to JSON.
+    """
+    resp = sdmx_request(
+        path,
+        accept="application/vnd.sdmx.structure+xml;version=2.1",
+        **params,
+    )
     return resp.content
 
 


### PR DESCRIPTION
## Summary

Closes #15.

OECD's `/dataflow` endpoint defaults to JSON when the request carries the generic `Accept: application/xml`. The JSON body then reaches `lxml.etree.fromstring` and blows up with `XMLSyntaxError: Start tag expected, '<' not found`.

The fix changes `sdmx_request_xml` to request the SDMX 2.1 standard structure media type:

```python
resp = sdmx_request(
    path,
    accept="application/vnd.sdmx.structure+xml;version=2.1",
    **params,
)
```

Verified with raw curl:

```bash
$ curl -s -H "Accept: application/vnd.sdmx.structure+xml;version=2.1" \
    -w "HTTP %{http_code} | ct=%{content_type} | size=%{size_download}\n" \
    "https://sdmx.oecd.org/public/rest/dataflow/all" -o /dev/null
HTTP 200 | ct=application/vnd.sdmx.structure+xml; version=2.1; charset=utf-8 | size=8372389
```

## Impact

- `opensdmx search`, `tree`, `siblings` on OECD now work end-to-end.
- `siblings` output on OECD is populated with `df_description` (previously empty because the resilience fallback kicked in).
- Side-effect: no regression on the other supported providers.

## Test plan

- [x] 105/105 pytest pass
- [x] Live smoke: `opensdmx search "gdp" --provider oecd` returns results (no crash)
- [x] Live smoke: `opensdmx siblings "OECD.TAD.ARP,DSD_AGRI_ENV@DF_AEI" --provider oecd` → 11 siblings with real descriptions ("Ammonia emissions", "Biodiversity", ...)
- [x] Live smoke: `search` on eurostat/istat/ecb/insee/bis/abs unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)