### PR TITLE
fix(http): retry only transient failures in sdmx_request

### DIFF
--- a/LOG.md
+++ b/LOG.md
@@ -1,5 +1,9 @@
 # LOG
 
+## 2026-05-08
+
+- fix(http): retry only on transient failures in `sdmx_request` — the previous `@retry` decorator had no `retry=` predicate, so tenacity retried on **any** exception, including `httpx.HTTPStatusError` for 4xx codes. On rate-limit-by-IP providers (e.g. ISTAT) this could turn a single 429 into three back-to-back hits and amplify the risk of a multi-day ban. Now retries are restricted to `httpx.TimeoutException`, `httpx.NetworkError`, `httpx.RemoteProtocolError`, and 5xx server errors (excluding 501 Not Implemented). Predicate exposed as `_is_retryable_exception` for testing.
+
 ## 2026-05-03 (v0.6.4)
 
 - ux: `constraints` summary table now shows a tip to use `--output json` for the full list of values

--- a/src/opensdmx/base.py
+++ b/src/opensdmx/base.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 import httpx
 import portalocker
-from tenacity import retry, stop_after_attempt, wait_exponential
+from tenacity import retry, retry_if_exception, stop_after_attempt, wait_exponential
 
 # Defaults for fields not specified in portals.json or custom providers
 _DEFAULTS: dict = {
@@ -237,11 +237,34 @@ def _rate_limit_check() -> None:
             pass
 
 
+def _is_retryable_exception(exc: BaseException) -> bool:
+    """Decide whether a request failure is worth retrying.
+
+    Retrying on 4xx (especially 429 Too Many Requests, 403 Forbidden) makes the
+    problem worse: it amplifies the request rate toward a provider that is
+    already rejecting us, and on rate-limit-by-IP providers (e.g. ISTAT) it can
+    turn a single 429 into a multi-day ban. We only retry on transient
+    conditions: network/timeout errors and 5xx server errors (excluding 501
+    Not Implemented, which is deterministic).
+    """
+    if isinstance(exc, (httpx.TimeoutException, httpx.NetworkError, httpx.RemoteProtocolError)):
+        return True
+    if isinstance(exc, httpx.HTTPStatusError):
+        status = exc.response.status_code
+        return 500 <= status < 600 and status != 501
+    return False
+
+
 def sdmx_request(path: str, accept: str = "application/xml", **params) -> httpx.Response:
     """Make a request to the active SDMX provider with retry logic."""
     url = f"{get_base_url()}/{path}"
 
-    @retry(stop=stop_after_attempt(3), wait=wait_exponential(multiplier=0.5, min=0.5, max=4), reraise=True)
+    @retry(
+        retry=retry_if_exception(_is_retryable_exception),
+        stop=stop_after_attempt(3),
+        wait=wait_exponential(multiplier=0.5, min=0.5, max=4),
+        reraise=True,
+    )
     def _do_request() -> httpx.Response:
         # Hold an exclusive file lock for the whole HTTP call. This serializes
         # requests to the same provider across processes, so the rate limit is

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
+import httpx
 import polars as pl
 import pytest
 
 from opensdmx.base import (
+    _is_retryable_exception,
     _provider_cache_key,
     _rate_limit_lock_file,
     sdmx_request,
@@ -278,3 +280,148 @@ class TestExtraHeaders:
             assert self._get_headers_sent(mock_client_class)["Accept"] == "application/json"
         finally:
             set_extra_headers({})
+
+
+# ---------------------------------------------------------------------------
+# Retry behavior — only retry transient failures, never 4xx
+# ---------------------------------------------------------------------------
+
+def _http_status_error(status: int) -> httpx.HTTPStatusError:
+    request = httpx.Request("GET", "http://test/example")
+    response = httpx.Response(status, request=request)
+    return httpx.HTTPStatusError(f"{status}", request=request, response=response)
+
+
+def _mock_client_raising_on_status(exc: Exception):
+    """Mock httpx.Client where get() returns a response whose raise_for_status raises exc."""
+    resp = MagicMock()
+    resp.content = b""
+    resp.raise_for_status = MagicMock(side_effect=exc)
+
+    client = MagicMock()
+    client.__enter__ = MagicMock(return_value=client)
+    client.__exit__ = MagicMock(return_value=False)
+    client.get = MagicMock(return_value=resp)
+
+    return patch("opensdmx.base.httpx.Client", return_value=client)
+
+
+def _mock_client_raising_on_get(exc: Exception):
+    """Mock httpx.Client where get() itself raises (e.g. timeout, network error)."""
+    client = MagicMock()
+    client.__enter__ = MagicMock(return_value=client)
+    client.__exit__ = MagicMock(return_value=False)
+    client.get = MagicMock(side_effect=exc)
+
+    return patch("opensdmx.base.httpx.Client", return_value=client)
+
+
+class TestIsRetryableExceptionPredicate:
+    """Unit tests for the retry predicate, independent of HTTP plumbing."""
+
+    def test_429_not_retryable(self):
+        assert _is_retryable_exception(_http_status_error(429)) is False
+
+    def test_403_not_retryable(self):
+        assert _is_retryable_exception(_http_status_error(403)) is False
+
+    def test_404_not_retryable(self):
+        assert _is_retryable_exception(_http_status_error(404)) is False
+
+    def test_401_not_retryable(self):
+        assert _is_retryable_exception(_http_status_error(401)) is False
+
+    def test_500_retryable(self):
+        assert _is_retryable_exception(_http_status_error(500)) is True
+
+    def test_502_retryable(self):
+        assert _is_retryable_exception(_http_status_error(502)) is True
+
+    def test_503_retryable(self):
+        assert _is_retryable_exception(_http_status_error(503)) is True
+
+    def test_504_retryable(self):
+        assert _is_retryable_exception(_http_status_error(504)) is True
+
+    def test_501_not_retryable(self):
+        """501 Not Implemented is deterministic — retrying never helps."""
+        assert _is_retryable_exception(_http_status_error(501)) is False
+
+    def test_connect_timeout_retryable(self):
+        assert _is_retryable_exception(httpx.ConnectTimeout("timeout")) is True
+
+    def test_read_timeout_retryable(self):
+        assert _is_retryable_exception(httpx.ReadTimeout("timeout")) is True
+
+    def test_connect_error_retryable(self):
+        assert _is_retryable_exception(httpx.ConnectError("conn refused")) is True
+
+    def test_unknown_exception_not_retryable(self):
+        """Don't retry on non-network exceptions (programming bugs, etc.)."""
+        assert _is_retryable_exception(ValueError("bad value")) is False
+        assert _is_retryable_exception(RuntimeError("oops")) is False
+
+
+class TestRetryBehavior:
+    """Integration-level: count actual HTTP attempts through sdmx_request."""
+
+    @pytest.fixture(autouse=True)
+    def _fast_retry(self, monkeypatch):
+        """Disable backoff waits so retry tests stay fast.
+
+        The @retry decorator on _do_request is rebuilt on every sdmx_request call,
+        so patching wait_exponential at the module name resolves before the
+        decorator is constructed.
+        """
+        from tenacity import wait_none
+        monkeypatch.setattr("opensdmx.base.wait_exponential", lambda **kwargs: wait_none())
+
+    def test_429_makes_one_call_no_retry(self, tmp_path, monkeypatch):
+        """A 429 must NOT trigger retries — would amplify the rate-limit hit."""
+        monkeypatch.setenv("OPENSDMX_CACHE_DIR", str(tmp_path))
+        with _mock_client_raising_on_status(_http_status_error(429)) as mock_client_class:
+            with pytest.raises(httpx.HTTPStatusError):
+                sdmx_request("data/TEST")
+        client_instance = mock_client_class.return_value
+        assert client_instance.get.call_count == 1
+
+    def test_403_makes_one_call_no_retry(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("OPENSDMX_CACHE_DIR", str(tmp_path))
+        with _mock_client_raising_on_status(_http_status_error(403)) as mock_client_class:
+            with pytest.raises(httpx.HTTPStatusError):
+                sdmx_request("data/TEST")
+        client_instance = mock_client_class.return_value
+        assert client_instance.get.call_count == 1
+
+    def test_404_makes_one_call_no_retry(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("OPENSDMX_CACHE_DIR", str(tmp_path))
+        with _mock_client_raising_on_status(_http_status_error(404)) as mock_client_class:
+            with pytest.raises(httpx.HTTPStatusError):
+                sdmx_request("data/TEST")
+        client_instance = mock_client_class.return_value
+        assert client_instance.get.call_count == 1
+
+    def test_503_retries_three_times(self, tmp_path, monkeypatch):
+        """5xx is transient — retry up to 3 attempts, then propagate."""
+        monkeypatch.setenv("OPENSDMX_CACHE_DIR", str(tmp_path))
+        with _mock_client_raising_on_status(_http_status_error(503)) as mock_client_class:
+            with pytest.raises(httpx.HTTPStatusError):
+                sdmx_request("data/TEST")
+        client_instance = mock_client_class.return_value
+        assert client_instance.get.call_count == 3
+
+    def test_connect_timeout_retries_three_times(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("OPENSDMX_CACHE_DIR", str(tmp_path))
+        with _mock_client_raising_on_get(httpx.ConnectTimeout("slow")) as mock_client_class:
+            with pytest.raises(httpx.ConnectTimeout):
+                sdmx_request("data/TEST")
+        client_instance = mock_client_class.return_value
+        assert client_instance.get.call_count == 3
+
+    def test_connect_error_retries_three_times(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("OPENSDMX_CACHE_DIR", str(tmp_path))
+        with _mock_client_raising_on_get(httpx.ConnectError("refused")) as mock_client_class:
+            with pytest.raises(httpx.ConnectError):
+                sdmx_request("data/TEST")
+        client_instance = mock_client_class.return_value
+        assert client_instance.get.call_count == 3


### PR DESCRIPTION
## Bug

The `@retry` decorator on `_do_request` in `src/opensdmx/base.py` had no `retry=` predicate, so tenacity defaulted to retrying on **any** exception — including `httpx.HTTPStatusError` raised by `resp.raise_for_status()` for 4xx codes.

The most damaging case is **429 Too Many Requests**: each rate-limited call turned into three back-to-back hits within ~1.5s. On providers that ban by IP (e.g. ISTAT, which blocks for 1–2 days when 5 queries/min is exceeded), this amplifies the very condition the rate limit was protecting against. The same problem applies to 403/404/401 — deterministic errors where retrying is pure waste.

## Fix

Restrict retries to genuinely transient conditions via a small predicate:

- `httpx.TimeoutException` (connect, read, write, pool)
- `httpx.NetworkError` (connect refused, etc.)
- `httpx.RemoteProtocolError`
- `httpx.HTTPStatusError` with status **5xx, excluding 501** (Not Implemented = deterministic)

Everything else propagates immediately. The predicate is exposed as `_is_retryable_exception` so it can be unit-tested independently of HTTP plumbing.

## Tests

`tests/test_http.py` adds:

- `TestIsRetryableExceptionPredicate` — 13 cases pinning behaviour for 401/403/404/429/500/501/502/503/504, timeouts, connect errors, and unrelated exceptions
- `TestRetryBehavior` — integration through `sdmx_request`, asserts `client.get.call_count == 1` for 429/403/404 and `== 3` for 503/timeout/connect-error

Backoff waits are no-op'd inside the test class via a fixture that swaps `wait_exponential` for `wait_none`, so the suite stays fast (~1.6s total for the new tests).

Full suite: 143/143 green.

## Test plan

- [x] `uv run pytest tests/ -v`
- [x] No regression in existing 124 tests
- [x] New retry-behavior tests pass