### PR TITLE
feat(istat): configurable constraints timeout + ConstraintsTimeout exception

### DIFF
--- a/LOG.md
+++ b/LOG.md
@@ -1,5 +1,12 @@
 # LOG
 
+## 2026-05-08
+
+- refactor(discovery): per-provider `constraint_timeout` / `constraint_max_retries` in `portals.json` instead of hardcoded values in `discovery.py`. Previously the 30 s + 1-attempt fast-fail was applied to **every** provider with `constraints_supported: true` (Eurostat, ABS, BIS, IMF, Derzhstat), silently disabling the 3-retry policy for transient failures (5xx, NetworkError, TimeoutException) on backends that aren't slow. Now only ISTAT carries the override (`constraint_timeout: 30`, `constraint_max_retries: 1`); all other providers keep the module timeout (300 s) and 3 retries. Precedence: `OPENSDMX_AVAILCONSTRAINT_TIMEOUT` env var > provider config > module default. CLI advisory generalized: gating on `provider.constraint_timeout` instead of `agency_id == "IT1"`.
+- feat(discovery): dedicated short timeout for the `availableconstraint` endpoint, configurable via `OPENSDMX_AVAILCONSTRAINT_TIMEOUT`. When the provider's availability backend is slow or unresponsive (documented case: ISTAT, TTFB > 180 s with zero bytes received), `opensdmx constraints` / `values` now fail fast instead of waiting up to 3 × 300 s on the global timeout. New `ConstraintsTimeout` exception parallel to `ConstraintsUnavailable`, exported from the package root. CLI prints a yellow advisory with the exact env var override.
+- feat(http): `sdmx_request` / `sdmx_request_xml` accept optional `_timeout` and `_max_retries` keyword overrides for per-call control of the HTTP timeout and retry attempts.
+- ux: ISTAT pre-warning before the first uncached constraints call now reflects the actual per-call timeout and the no-retry behavior (was a stale "30–120 s" estimate inherited from the old global-timeout regime).
+
 ## 2026-05-08 (v0.6.5)
 
 - fix(http): retry only on transient failures in `sdmx_request` — the previous `@retry` decorator had no `retry=` predicate, so tenacity retried on **any** exception, including `httpx.HTTPStatusError` for 4xx codes. On rate-limit-by-IP providers (e.g. ISTAT) this could turn a single 429 into three back-to-back hits and amplify the risk of a multi-day ban. Now retries are restricted to `httpx.TimeoutException`, `httpx.NetworkError`, `httpx.RemoteProtocolError`, and 5xx server errors (excluding 501 Not Implemented). Predicate exposed as `_is_retryable_exception` for testing.

--- a/README.md
+++ b/README.md
@@ -500,6 +500,7 @@ Environment variables:
 | `OPENSDMX_DATAFLOWS_CACHE_TTL` | Dataset catalog TTL in seconds (default: `604800` — 7 days) |
 | `OPENSDMX_METADATA_CACHE_TTL` | Structure/codelist TTL in seconds (default: `2592000` — 30 days) |
 | `OPENSDMX_CONSTRAINTS_CACHE_TTL` | Constraints TTL in seconds (default: `604800` — 7 days) |
+| `OPENSDMX_AVAILCONSTRAINT_TIMEOUT` | Per-call timeout (seconds) for the `availableconstraint` endpoint, with no retry. Default: `30`. Useful when a provider's availability backend is slow or unresponsive (e.g. ISTAT) and you want `opensdmx constraints` / `values` to fail fast instead of blocking on the global request timeout. |
 
 See `.env.example` for a ready-to-use template.
 

--- a/docs/future-ideas.md
+++ b/docs/future-ideas.md
@@ -26,16 +26,16 @@ Feynman generates a `.provenance.md` for every output. opensdmx already has some
 
 Feynman has a `Verifier` agent that validates every citation. opensdmx could have a `verify` command that takes a numeric value and searches it across alternative providers — "is this figure confirmed by both IMF and OECD?"
 
-**4. Natural language statistical research assistant**
+**4. Natural language statistical research assistant** *(partially implemented)*
 
 The most ambitious idea: a mode where the user asks a question in natural language and the system:
 
-1. Discovers relevant dataflows (already works via `catalog`)
-2. Resolves dimensions and filters (already works via `values`/`constraints`)
-3. Fetches the data
+1. Discovers relevant dataflows (already works via `catalog`) ✓
+2. Resolves dimensions and filters (already works via `values`/`constraints`) ✓
+3. Fetches the data ✓
 4. Answers with figures traced to the exact SDMX source
 
-This would be the statistical equivalent of Feynman.
+The `sdmx-explorer` skill is already a working embryo of this pattern. What's missing: persistent state, structured output artifacts, verification loops.
 
 ### Architectural Direction
 
@@ -84,6 +84,36 @@ Example: `opensdmx search --all-providers "inflation"`.
 **10. SDMX 3.0 / REST 2.0** *(low priority, high effort)*
 
 `sdmx1` and `pysdmx` (BIS) already support SDMX 3.0. No mainstream provider requires it today, but it is an emerging requirement. Defer until Eurostat or OECD mandate REST 2.0.
+
+---
+
+## rsdmx-Inspired Improvements
+
+Patterns from open issues in [eblondel/rsdmx](https://github.com/eblondel/rsdmx) (R package for SDMX) that reveal unmet user needs.
+
+**11. Hierarchical parent labels in codelist enrichment** *(low priority, medium effort)*
+
+When enriching a dataset with DSD labels, also return parent code labels (and grandparent, if present). rsdmx #109 has been open since 2016 — a persistent user need. opensdmx already does label lookup but ignores hierarchy. Useful for geographic hierarchies (country → region → city) and classification trees.
+
+**Feasibility note (2026-05-01):** SDMX 2.1 defines a `<structure:Parent><Ref id="..."/></structure:Parent>` element for explicit hierarchy. ISTAT uses it (e.g. CL_ITTER107: 12,465/12,471 codes have a parent). However, Eurostat and OECD do not — their hierarchy is implicit in the code structure (`OC1 → OC11 → OC111`) and would require provider-specific heuristics. Two separate code paths needed for limited gain: downgraded to low priority.
+
+**12. Codelist filtered by constraint** *(low priority, low effort)*
+
+`opensdmx values` currently returns all values declared in the codelist, not only those present in the dataset. rsdmx #190 exposes the same bug. Fix: apply the `AvailableConstraint` to filter the codelist before returning it. Note: `opensdmx constraints` already does this correctly — the gap is only in `values`.
+
+**Coverage note:** the `sdmx-explorer` skill already addresses this for AI-orchestrated use: it explicitly instructs never to use `opensdmx values` to validate filter codes and routes all constraint checks through `opensdmx constraints`. The remaining gap is purely UX for human users running `values` directly from the terminal.
+
+**13. Custom HTTP headers for authenticated providers** *(medium priority, low effort)*
+
+Some providers (e.g. ABS Australia) require API key in the HTTP header, not the query string. rsdmx #162. opensdmx has no mechanism for this. A `--header "X-Api-Key: ..."` flag or a per-provider `headers:` key in `providers.yaml` would cover the gap.
+
+**14. Auto-coercion of TIME_PERIOD to ISO dates** *(implemented)*
+
+`parse_time_period()` is applied by default in `retrieval.py` on every `get` call and in `plot`. No action needed.
+
+**15. Dataset validation against DSD** *(low priority, medium effort)*
+
+A command `opensdmx validate <dataflow> [--file data.csv]` that checks a dataset for compliance with its DSD: required dimensions present, values in declared codelists, observation attributes valid. rsdmx #107.
 
 ### Related projects to monitor
 

--- a/docs/provider-proposals.md
+++ b/docs/provider-proposals.md
@@ -1,0 +1,80 @@
+# Provider Proposals
+
+Proposals for improvements that SDMX data providers could implement on their side to make
+opensdmx (and any SDMX 2.1 client) more usable. Each section targets a specific provider,
+documents the empirically observed problem, and describes the requested change.
+
+---
+
+## ISTAT
+
+### P-ISTAT-01: Honor the key filter in `availableconstraint`
+
+**Status:** Not implemented (verified 2026-05-09)
+
+#### Problem
+
+The SDMX 2.1 REST specification allows clients to pass a dimension key when querying the
+`availableconstraint` endpoint:
+
+```
+GET /availableconstraint/{flowRef}/{key}/{providerRef}?mode=available
+```
+
+The `{key}` parameter lets the client pre-filter the constraint by fixing one or more
+dimension values. For example, to retrieve only the codes that exist for the municipality
+of Palermo (ISTAT code `082053`):
+
+```
+GET https://esploradati.istat.it/SDMXWS/rest/availableconstraint/
+        22_289_DF_DCIS_POPRES1_24/.082053..../all?mode=available
+```
+
+**ISTAT accepts the URL (HTTP 200)** but ignores the key filter entirely. The response
+contains all 8,128 Italian municipalities regardless of the `.082053....` key — identical
+to calling the endpoint without any key:
+
+```
+# Response with key filter .082053....
+REF_AREA: 8128 values — ['001001', '001002', '001003', ...]
+```
+
+As a result, the response takes **~77 seconds** to arrive even with the filter, because the
+server performs a full-cube scan. For large datasets ("all municipalities × single ages",
+~8k × 100+ dimensions), the unfiltered call consistently exceeds the 90-second client
+timeout and is unusable.
+
+#### Impact
+
+- `opensdmx constraints` fails with a timeout for any "all municipalities" dataset
+  (e.g., `22_289_DF_DCIS_POPRES1_24`, `22_289_DF_DCIS_POPRES1_22`, …)
+- Users cannot discover which codes are valid for a specific territory without fetching
+  the full data response
+- Any SDMX 2.1 client that relies on `availableconstraint` for code validation is blocked
+  on these datasets
+
+#### Requested change
+
+Implement server-side filtering in the `availableconstraint` response: when a key is
+provided, restrict the enumerated code combinations to only those dimension slices that
+match the key. A correct implementation of the example above would return:
+
+```
+REF_AREA: 1 value — ['082053']
+DATA_TYPE: 1 value — ['JAN']
+SEX: 3 values — ['1', '2', '9']
+AGE: 102 values — ['TOTAL', 'Y_GE100', 'Y0', 'Y1', …]
+…
+```
+
+This would reduce response time from ~77s to sub-second for a single-municipality query,
+making the endpoint practical for interactive use.
+
+#### Workaround (client-side)
+
+Until the server is fixed, opensdmx bypasses the constraint step on timeout and falls
+back to direct `data` requests using codes from the static codelist (`/codelist`). This
+is less reliable because codelists contain all theoretically possible codes, not just
+those present in the dataset.
+
+---

--- a/skills/sdmx-explorer/references/istat-flow.md
+++ b/skills/sdmx-explorer/references/istat-flow.md
@@ -43,14 +43,45 @@ opensdmx constraints <dataflow_id> DATA_TYPE --provider istat
 
 This is the most important step. The `values` codelist is theoretical — many
 codes will not exist in the actual dataflow. Each failed `get` attempt costs
-≥13 s due to rate limiting, so verifying with `constraints` first (even when
-that endpoint takes 30–60 s on first call) is far cheaper than multiple failed
-`get` attempts.
+≥13 s due to rate limiting, so verifying with `constraints` first is far
+cheaper than multiple failed `get` attempts.
 
-**Exception — municipal-level datasets.** When `REF_AREA` contains thousands
-of territory codes, `constraints` on that dimension may time out. In that case
-only, fall back to `values` + `grep` for territories and verify with one narrow
-`get`. For all other dimensions, `constraints` remains the right call.
+The ISTAT `availableconstraint` endpoint has a default timeout of **30 s**
+(configured in `portals.json`). On success the result is cached for 7 days.
+The timeout can be raised via the `OPENSDMX_AVAILCONSTRAINT_TIMEOUT` environment
+variable — but raising it is rarely useful (see below).
+
+**Exception — "all municipalities" datasets.** Dataflows that cover all ~8,000
+Italian municipalities at single-age granularity (e.g. `22_289_DF_DCIS_POPRES1_24`,
+`22_289_DF_DCIS_POPRES1_22`) will **always** time out regardless of the timeout
+setting. Empirically verified: ISTAT performs a full-cube scan and returns
+all 8,128 territory codes even when a key filter is passed
+(`/availableconstraint/{id}/.082053..../all` → still 8,128 codes, ~77 s).
+Raising `OPENSDMX_AVAILCONSTRAINT_TIMEOUT` beyond 90 s does not help for these
+datasets.
+
+When `constraints` times out, the CLI prints:
+
+```
+⚠ Constraints request timed out after 30s for <dataflow_id>.
+The provider's availableconstraint endpoint is slow or unresponsive.
+Try again later, or raise the limit: OPENSDMX_AVAILCONSTRAINT_TIMEOUT=60 opensdmx constraints <dataflow_id>
+Data is still accessible: opensdmx get <dataflow_id> ...
+```
+
+**Fallback flow for municipal-level datasets:**
+
+1. Use `opensdmx values <dataflow_id> DATA_TYPE --provider istat` (and other
+   non-geographic dimensions) to get candidate codes from the codelist.
+2. Use `opensdmx values <dataflow_id> REF_AREA --provider istat | grep -i "palermo"`
+   to find the territory code (e.g. `082053`).
+3. Run a narrow `get` with `--last-n 1` or a 1-year period to confirm which
+   codes actually exist in the dataset before downloading everything.
+4. If `get` returns 404 or `NoRecordsFound`, iterate on the code (try base form
+   without version suffix, try a different DATA_TYPE).
+
+For all other ISTAT datasets (national, regional, provincial level),
+`constraints` responds within the 30 s timeout and remains the right call.
 
 ### Step 4 — build the query using verified codes
 

--- a/src/opensdmx/__init__.py
+++ b/src/opensdmx/__init__.py
@@ -9,6 +9,7 @@ except PackageNotFoundError:
 
 from .base import get_provider, set_provider, set_timeout, set_extra_headers, get_extra_headers
 from .discovery import (
+    ConstraintsTimeout,
     ConstraintsUnavailable,
     all_available,
     dimensions_info,
@@ -25,6 +26,7 @@ from .embed import build_embeddings, semantic_search
 from .cli import main
 
 __all__ = [
+    "ConstraintsTimeout",
     "ConstraintsUnavailable",
     "set_provider",
     "get_provider",

--- a/src/opensdmx/base.py
+++ b/src/opensdmx/base.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 import httpx
 import portalocker
-from tenacity import retry, retry_if_exception, stop_after_attempt, wait_exponential
+from tenacity import Retrying, retry_if_exception, stop_after_attempt, wait_exponential
 
 # Defaults for fields not specified in portals.json or custom providers
 _DEFAULTS: dict = {
@@ -255,16 +255,30 @@ def _is_retryable_exception(exc: BaseException) -> bool:
     return False
 
 
-def sdmx_request(path: str, accept: str = "application/xml", **params) -> httpx.Response:
-    """Make a request to the active SDMX provider with retry logic."""
-    url = f"{get_base_url()}/{path}"
+def sdmx_request(
+    path: str,
+    accept: str = "application/xml",
+    *,
+    _timeout: float | None = None,
+    _max_retries: int | None = None,
+    **params,
+) -> httpx.Response:
+    """Make a request to the active SDMX provider with retry logic.
 
-    @retry(
+    `_timeout` and `_max_retries` override the module defaults for this call only
+    (used e.g. by `availableconstraint` discovery to fail fast on slow backends).
+    """
+    url = f"{get_base_url()}/{path}"
+    effective_timeout = _timeout if _timeout is not None else globals()["_timeout"]
+    effective_attempts = _max_retries if _max_retries is not None else 3
+
+    retryer = Retrying(
         retry=retry_if_exception(_is_retryable_exception),
-        stop=stop_after_attempt(3),
+        stop=stop_after_attempt(effective_attempts),
         wait=wait_exponential(multiplier=0.5, min=0.5, max=4),
         reraise=True,
     )
+
     def _do_request() -> httpx.Response:
         # Hold an exclusive file lock for the whole HTTP call. This serializes
         # requests to the same provider across processes, so the rate limit is
@@ -279,7 +293,7 @@ def sdmx_request(path: str, accept: str = "application/xml", **params) -> httpx.
                 _rate_limit_file().write_text(str(time.time()))
             except OSError:
                 pass
-            with httpx.Client(timeout=_timeout, follow_redirects=True) as client:
+            with httpx.Client(timeout=effective_timeout, follow_redirects=True) as client:
                 user_agent = os.environ.get(
                     "OPENSDMX_USER_AGENT",
                     get_provider().get("user_agent") or "opensdmx Python package",
@@ -293,10 +307,16 @@ def sdmx_request(path: str, accept: str = "application/xml", **params) -> httpx.
                 resp.raise_for_status()
                 return resp
 
-    return _do_request()
+    return retryer(_do_request)
 
 
-def sdmx_request_xml(path: str, **params):
+def sdmx_request_xml(
+    path: str,
+    *,
+    _timeout: float | None = None,
+    _max_retries: int | None = None,
+    **params,
+):
     """Make a request and return the raw XML bytes.
 
     Uses the SDMX 2.1 structure Accept header — the generic "application/xml"
@@ -305,6 +325,8 @@ def sdmx_request_xml(path: str, **params):
     resp = sdmx_request(
         path,
         accept="application/vnd.sdmx.structure+xml;version=2.1",
+        _timeout=_timeout,
+        _max_retries=_max_retries,
         **params,
     )
     return resp.content

--- a/src/opensdmx/cli.py
+++ b/src/opensdmx/cli.py
@@ -480,7 +480,7 @@ def constraints(
     import polars as pl
 
     from . import load_dataset
-    from .discovery import ConstraintsUnavailable, get_available_values, get_dimension_values
+    from .discovery import ConstraintsTimeout, ConstraintsUnavailable, get_available_values, get_dimension_values
     from .db_cache import get_cached_available_constraints
 
     try:
@@ -491,10 +491,14 @@ def constraints(
         raise typer.Exit(1)
 
     provider_cfg = get_provider()
-    if provider_cfg.get("agency_id") == "IT1" and get_cached_available_constraints(dataset_id) is None:
+    provider_constraint_timeout = provider_cfg.get("constraint_timeout")
+    if provider_constraint_timeout is not None and get_cached_available_constraints(dataset_id) is None:
+        import os as _os
+        _t = float(_os.environ.get("OPENSDMX_AVAILCONSTRAINT_TIMEOUT", str(provider_constraint_timeout)))
         err_console.print(
-            "[yellow]⚠ ISTAT: first constraints call may take 30–120 s. "
-            "Results will be cached for 7 days.[/yellow]"
+            f"[yellow]⚠ {provider_cfg.get('name', 'Provider')}: first constraints call "
+            f"(timeout {_t:.0f} s, no retry). Results cached 7 days on success; on timeout, raise "
+            f"OPENSDMX_AVAILCONSTRAINT_TIMEOUT.[/yellow]"
         )
 
     try:
@@ -504,6 +508,16 @@ def constraints(
         err_console.print(
             f"[yellow]⚠ Constraints not available for [bold]{dataset_id}[/bold] "
             f"(dataflow is hidden or not yet public).[/yellow]\n"
+            f"Data is still accessible:  opensdmx get {dataset_id} ..."
+        )
+        raise typer.Exit(0)
+    except ConstraintsTimeout as e:
+        err_console.print(
+            f"[yellow]⚠ Constraints request timed out after {e.timeout:.0f}s for "
+            f"[bold]{dataset_id}[/bold].[/yellow]\n"
+            f"The provider's [italic]availableconstraint[/italic] endpoint is slow or unresponsive. "
+            f"Try again later, or raise the limit:  "
+            f"[cyan]OPENSDMX_AVAILCONSTRAINT_TIMEOUT=60 opensdmx constraints {dataset_id}[/cyan]\n"
             f"Data is still accessible:  opensdmx get {dataset_id} ..."
         )
         raise typer.Exit(0)

--- a/src/opensdmx/discovery.py
+++ b/src/opensdmx/discovery.py
@@ -6,7 +6,21 @@ from __future__ import annotations
 class ConstraintsUnavailable(Exception):
     """Raised when the availableconstraint endpoint returns 500 (hidden/not-yet-public dataflow)."""
 
+
+class ConstraintsTimeout(Exception):
+    """Raised when the availableconstraint endpoint times out (slow provider backend)."""
+
+    def __init__(self, df_id: str, timeout: float):
+        self.df_id = df_id
+        self.timeout = timeout
+        super().__init__(
+            f"Constraints request timed out after {timeout:.1f}s for {df_id}. "
+            f"Set OPENSDMX_AVAILCONSTRAINT_TIMEOUT to override."
+        )
+
+
 import logging
+import os
 import time
 
 logger = logging.getLogger(__name__)
@@ -411,9 +425,24 @@ def get_available_values(dataset: dict) -> dict[str, pl.DataFrame]:
         path = f"{constraint_endpoint}/{provider['agency_id']}/{df_id}"
     else:
         path = f"{constraint_endpoint}/{df_id}{constraint_suffix}"
+
+    # Precedence: env var > provider config > module default (None → fallback in sdmx_request).
+    env_timeout = os.environ.get("OPENSDMX_AVAILCONSTRAINT_TIMEOUT")
+    if env_timeout:
+        constraint_timeout = float(env_timeout)
+    else:
+        provider_timeout = provider.get("constraint_timeout")
+        constraint_timeout = float(provider_timeout) if provider_timeout is not None else None
+    constraint_max_retries = provider.get("constraint_max_retries")  # None → default 3 in sdmx_request
+
     try:
         constraint_params = provider.get("constraint_params", {"references": "none"})
-        content = sdmx_request_xml(path, **constraint_params)
+        content = sdmx_request_xml(
+            path,
+            _timeout=constraint_timeout,
+            _max_retries=constraint_max_retries,
+            **constraint_params,
+        )
         root, ns = xml_parse(content)
 
         common_ns = ns.get("common", "")
@@ -435,8 +464,17 @@ def get_available_values(dataset: dict) -> dict[str, pl.DataFrame]:
                 if values:
                     result[dim_id] = values
 
+    except httpx.TimeoutException as e:
+        provider_name = provider.get("name", "unknown")
+        # If no override was set, the module default applied — surface that to the user.
+        from .base import _timeout as _module_timeout
+        effective_timeout = constraint_timeout if constraint_timeout is not None else _module_timeout
+        logger.warning(
+            "availableconstraint timed out after %.1fs for %s on provider %s",
+            effective_timeout, df_id, provider_name,
+        )
+        raise ConstraintsTimeout(df_id, effective_timeout) from e
     except Exception as e:
-        import httpx
         if isinstance(e, httpx.HTTPStatusError) and e.response.status_code == 500:
             raise ConstraintsUnavailable(df_id) from e
         logger.warning("Could not retrieve available values: %s", e)

--- a/src/opensdmx/portals.json
+++ b/src/opensdmx/portals.json
@@ -38,6 +38,8 @@
     "language": "it",
     "constraint_path_suffix": "/all/all",
     "constraint_params": {"mode": "available"},
+    "constraint_timeout": 30,
+    "constraint_max_retries": 1,
     "constraints_supported": true,
     "last_n_supported": true,
     "categories_supported": true

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -425,3 +425,110 @@ class TestRetryBehavior:
                 sdmx_request("data/TEST")
         client_instance = mock_client_class.return_value
         assert client_instance.get.call_count == 3
+
+    def test_max_retries_override_one_attempt(self, tmp_path, monkeypatch):
+        """_max_retries=1 must short-circuit the default 3 attempts (timeout fast-fail path)."""
+        monkeypatch.setenv("OPENSDMX_CACHE_DIR", str(tmp_path))
+        with _mock_client_raising_on_get(httpx.ConnectTimeout("slow")) as mock_client_class:
+            with pytest.raises(httpx.ConnectTimeout):
+                sdmx_request("data/TEST", _max_retries=1)
+        client_instance = mock_client_class.return_value
+        assert client_instance.get.call_count == 1
+
+    def test_timeout_override_passed_to_httpx_client(self, tmp_path, monkeypatch):
+        """_timeout override must reach httpx.Client(timeout=...)."""
+        monkeypatch.setenv("OPENSDMX_CACHE_DIR", str(tmp_path))
+        with _mock_http_client(b"") as mock_client_class:
+            sdmx_request("data/TEST", _timeout=7.5)
+        # Call kwargs of httpx.Client(...)
+        _, kwargs = mock_client_class.call_args
+        assert kwargs["timeout"] == 7.5
+
+
+# ---------------------------------------------------------------------------
+# get_available_values — fast-fail on availableconstraint timeout
+# ---------------------------------------------------------------------------
+
+class TestAvailableConstraintTimeout:
+    """Verify that availableconstraint times out fast and raises ConstraintsTimeout.
+
+    Provider-specific tuning lives in portals.json (constraint_timeout,
+    constraint_max_retries). Only providers that opt in get the fast-fail behavior;
+    the rest keep the default 3 retries on transient failures.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _fast_retry(self, monkeypatch):
+        from tenacity import wait_none
+        monkeypatch.setattr("opensdmx.base.wait_exponential", lambda **kwargs: wait_none())
+        # Force db_cache to re-init schema for the per-test tmp cache dir.
+        monkeypatch.setattr("opensdmx.db_cache._DB_INITIALIZED", False)
+        # Skip per-provider rate-limit sleep so multi-attempt cases stay fast.
+        monkeypatch.setattr("opensdmx.base._rate_limit_check", lambda: None)
+
+    def _dataset(self, df_id: str = "TEST_DF") -> dict:
+        return {
+            "df_id": df_id,
+            "version": "1.0",
+            "df_description": "Test",
+            "df_structure_id": "TEST_DSD",
+            "dimensions": {"FREQ": {"id": "FREQ", "position": 0, "codelist_id": None}},
+            "filters": {"FREQ": "."},
+        }
+
+    def test_istat_timeout_raises_constraints_timeout(self, tmp_path, monkeypatch):
+        """ISTAT (configured constraint_timeout=30, max_retries=1) → fast-fail in 1 call."""
+        from opensdmx.discovery import ConstraintsTimeout, get_available_values
+
+        monkeypatch.setenv("OPENSDMX_CACHE_DIR", str(tmp_path))
+        set_provider("istat")
+        ds = self._dataset(df_id="TIMEOUT_TEST_DF")
+        with _mock_client_raising_on_get(httpx.ConnectTimeout("slow")) as mock_client_class:
+            with pytest.raises(ConstraintsTimeout) as excinfo:
+                get_available_values(ds)
+        assert excinfo.value.df_id == "TIMEOUT_TEST_DF"
+        assert excinfo.value.timeout == 30.0
+        # Single attempt, no retry — would otherwise be 3 calls.
+        assert mock_client_class.return_value.get.call_count == 1
+
+    def test_env_var_overrides_provider_timeout(self, tmp_path, monkeypatch):
+        """OPENSDMX_AVAILCONSTRAINT_TIMEOUT must override the per-provider value."""
+        from opensdmx.discovery import ConstraintsTimeout, get_available_values
+
+        monkeypatch.setenv("OPENSDMX_CACHE_DIR", str(tmp_path))
+        monkeypatch.setenv("OPENSDMX_AVAILCONSTRAINT_TIMEOUT", "12.0")
+        set_provider("istat")
+        ds = self._dataset(df_id="ENV_TIMEOUT_DF")
+        with _mock_client_raising_on_get(httpx.ConnectTimeout("slow")) as mock_client_class:
+            with pytest.raises(ConstraintsTimeout) as excinfo:
+                get_available_values(ds)
+        assert excinfo.value.timeout == 12.0
+        _, kwargs = mock_client_class.call_args
+        assert kwargs["timeout"] == 12.0
+
+    def test_provider_without_override_keeps_default_retries(self, tmp_path, monkeypatch):
+        """Eurostat (no constraint_timeout in portals.json) → 3 retry, module timeout.
+
+        Regression guard: the previous hardcoded 30s + 1 attempt was applied to all
+        providers, which silently disabled retries for Eurostat/ABS/BIS/IMF/Derzhstat.
+        """
+        from opensdmx.discovery import ConstraintsTimeout, get_available_values
+
+        monkeypatch.setenv("OPENSDMX_CACHE_DIR", str(tmp_path))
+        # eurostat is set by the module-level autouse fixture
+        ds = self._dataset(df_id="EUROSTAT_NO_OVERRIDE_DF")
+        with _mock_client_raising_on_get(httpx.ConnectTimeout("slow")) as mock_client_class:
+            with pytest.raises(ConstraintsTimeout):
+                get_available_values(ds)
+        # Default retries: 3 attempts.
+        assert mock_client_class.return_value.get.call_count == 3
+
+    def test_500_still_raises_constraints_unavailable(self, tmp_path, monkeypatch):
+        """Regression: 500 path (hidden dataflow) must keep working."""
+        from opensdmx.discovery import ConstraintsUnavailable, get_available_values
+
+        monkeypatch.setenv("OPENSDMX_CACHE_DIR", str(tmp_path))
+        ds = self._dataset(df_id="HIDDEN_DF_500")
+        with _mock_client_raising_on_status(_http_status_error(500)):
+            with pytest.raises(ConstraintsUnavailable):
+                get_available_values(ds)


### PR DESCRIPTION
## Summary

- `ConstraintsTimeout` exception raised (and exported) when the `availableconstraint` endpoint times out — previously the error was swallowed silently
- `sdmx_request` / `sdmx_request_xml` accept per-call `_timeout` and `_max_retries` overrides, keeping the public API unchanged
- ISTAT configured with `constraint_timeout=30s` and `constraint_max_retries=1` in `portals.json` (no retry on slow constraint calls)
- CLI prints an actionable message with the `OPENSDMX_AVAILCONSTRAINT_TIMEOUT` env var hint instead of exiting with a generic error
- Slow-provider warning generalized: triggers for any provider that has `constraint_timeout` set, not ISTAT-specific

## Background (empirical findings)

Tested today on `22_289_DF_DCIS_POPRES1_24` ("all municipalities × single age"):
- `availableconstraint` with key filter (`.082053....`) → HTTP 200 but still returns 8,128 municipalities (~77s) — ISTAT ignores the key
- `contentconstraint` → HTTP 200 in **0.66s** with correct codes (see issue #24)

Raising `OPENSDMX_AVAILCONSTRAINT_TIMEOUT` does not help for "all municipalities" datasets; the fallback flow (documented in `istat-flow.md`) is the right path.

## Docs

- `docs/provider-proposals.md` — new file, proposal P-ISTAT-01: honor key filter in availableconstraint
- `skills/sdmx-explorer/references/istat-flow.md` — expanded Step 3 with timeout behavior, env var, empirical findings, and concrete fallback flow

## Test plan

- [x] 149 tests pass (`uv run pytest`)
- [x] New tests in `TestAvailableConstraintTimeout` cover: timeout raises `ConstraintsTimeout`, env var override, default retry count, 500 still raises `ConstraintsUnavailable`

🤖 Generated with [Claude Code](https://claude.com/claude-code)