### PR TITLE
fix(abs): constraint_params:{} to avoid 500 on availableconstraint

### DIFF
--- a/LOG.md
+++ b/LOG.md
@@ -1,5 +1,15 @@
 # LOG
 
+## 2026-05-10 — fix(abs): constraint_params: {} to avoid 500 on availableconstraint
+
+- fix(portals): added `constraint_params: {}` to ABS entry — the server returns 500
+  when `references=none` is sent as query parameter (default for all providers);
+  omitting all params gives 200 and correct constraint data.
+- probe(issue #27): BIS, Derzhstat, IMF already work via `availableconstraint` without
+  any portals.json change; the original probe only tested `contentconstraint`, which
+  those providers don't implement. ABS was the only broken case.
+- Updated `tmp/contentconstraint-probe.md` with current findings.
+
 ## 2026-05-09 — v0.7.0: serieskeysonly fallback for constraints timeout
 
 - feat(discovery): `_parse_serieskeys_xml()` parses GenericData `detail=serieskeysonly` responses into `{dim_id: [unique sorted values]}`.

--- a/src/opensdmx/portals.json
+++ b/src/opensdmx/portals.json
@@ -100,6 +100,7 @@
     "description": "Official Australian statistics. Covers population, economy, employment, trade, prices and environment for Australia and its territories.",
     "base_url": "https://data.api.abs.gov.au/rest",
     "agency_id": "ABS",
+    "constraint_params": {},
     "constraints_supported": true,
     "last_n_supported": true,
     "categories_supported": true


### PR DESCRIPTION
## Summary

- **Root cause**: ABS `availableconstraint` returns HTTP 500 when `references=none` is appended as a query parameter (the default for all providers). Without query params the same endpoint returns 200 with correct constraint data.
- **Fix**: added `"constraint_params": {}` to ABS entry in `portals.json`, overriding the default `{"references": "none"}`.
- **Probe findings** (issue #27 follow-up): BIS, Derzhstat, and IMF already work via `availableconstraint` without any changes — the original probe only tested `contentconstraint`, which those providers don't implement.

## Test plan

- [x] `OPENSDMX_PROVIDER=abs opensdmx constraints POPULATION_CLOCK` → 4 dims, 200 OK
- [x] `OPENSDMX_PROVIDER=abs opensdmx constraints ABS_LABOUR_ACCT` → 4 dims, 200 OK
- [x] `OPENSDMX_PROVIDER=abs opensdmx constraints LABOUR_ACCT_Q` → 5 dims, 200 OK
- [x] `OPENSDMX_PROVIDER=bis opensdmx constraints WS_XRU` → 4 dims (already working, no change)
- [x] `OPENSDMX_PROVIDER=imf opensdmx constraints "IMF.RES,WEO"` → 3 dims (already working, no change)
- [x] `OPENSDMX_PROVIDER=derzhstat opensdmx constraints DF_GROUND_TRANSPORT_Q` → 13 dims (already working, no change)
- [x] 159 unit tests pass

**Known asymmetry**: `_fallback_availableconstraint()` hardcodes `references=none`. ABS never hits this path (it uses default `availableconstraint`, not `contentconstraint`), so not blocking — documented in `tmp/contentconstraint-probe.md`.

Closes #27