### PR TITLE
feat: split rate limiter for data vs structure requests

### DIFF
--- a/LOG.md
+++ b/LOG.md
@@ -1,5 +1,14 @@
 # LOG
 
+## 2026-05-10 — feat: split rate limiter for data vs structure requests (issue #2)
+
+- feat(base): `_use_split_rate_limit(is_data)` — returns True only when `is_data=True` and the provider defines `data_rate_limit`. Keeps the unified timer for all providers without that key, preserving identical behavior for ISTAT, Eurostat, Derzhstat, and all others.
+- feat(base): `_rate_limit_file` / `_rate_limit_lock_file` / `_rate_limit_check` accept `is_data=False`. When split is active, data calls use `{provider}.data.log` + `{provider}.data.lock`; structure calls keep `{provider}.log` + `{provider}.lock` — fully independent clocks and locks.
+- feat(base): `sdmx_request` gains `_is_data=False` kwarg, propagated to the rate-limit machinery inside `_do_request`.
+- feat(base): all three data paths in `sdmx_request_csv` pass `_is_data=True` (World Bank JSON, Eurostat SDMX-CSV, generic CSV).
+- feat(portals): OECD gains `"data_rate_limit": 60` (1 data download/min, per official OECD docs). Structure calls (search, info, constraints) are unthrottled.
+- test: 6 new tests in `TestSplitRateLimit` covering split/no-split detection, lock file naming, and correct lock selection per call type. Updated two existing `_rate_limit_check` mocks to accept the new `is_data` kwarg. Total: 165 tests pass.
+
 ## 2026-05-10 — v0.7.1: fix(abs): constraint_params: {} to avoid 500 on availableconstraint
 
 - fix(portals): added `constraint_params: {}` to ABS entry — the server returns 500

--- a/src/opensdmx/base.py
+++ b/src/opensdmx/base.py
@@ -187,12 +187,18 @@ def _rate_limit_dir() -> Path:
     return d
 
 
-def _rate_limit_file() -> Path:
+def _use_split_rate_limit(is_data: bool) -> bool:
+    """True when this call should use the dedicated data rate limit."""
+    return is_data and get_provider().get("data_rate_limit") is not None
+
+
+def _rate_limit_file(is_data: bool = False) -> Path:
     """Return per-provider rate limit timestamp file."""
-    return _rate_limit_dir() / f"{_provider_cache_key()}.log"
+    suffix = ".data.log" if _use_split_rate_limit(is_data) else ".log"
+    return _rate_limit_dir() / f"{_provider_cache_key()}{suffix}"
 
 
-def _rate_limit_lock_file() -> Path:
+def _rate_limit_lock_file(is_data: bool = False) -> Path:
     """Return per-provider lock file.
 
     Held for the entire HTTP call so that requests to the same provider are
@@ -200,21 +206,31 @@ def _rate_limit_lock_file() -> Path:
     callers read the same timestamp, sleep the same amount, and fire HTTP
     requests nearly simultaneously — defeating the rate limit.
     """
-    return _rate_limit_dir() / f"{_provider_cache_key()}.lock"
+    suffix = ".data.lock" if _use_split_rate_limit(is_data) else ".lock"
+    return _rate_limit_dir() / f"{_provider_cache_key()}{suffix}"
 
 
-def _rate_limit_check() -> None:
+def _rate_limit_check(is_data: bool = False) -> None:
     """Wait if needed to respect the provider's rate limit.
 
+    When the provider defines `data_rate_limit` and `is_data=True`, uses that
+    interval with a separate timestamp/lock file so data and structure calls
+    don't block each other. All other providers use a single unified timer
+    (identical to previous behavior).
+
     Reads the last-call timestamp from the per-user rate-limit directory
-    (`_rate_limit_dir()`, under the resolved cache base). If less than rate_limit seconds
-    have passed since the last HTTP request was sent, sleeps for the remaining
-    time. The timestamp is written at request start (before the HTTP call), so
-    the interval is measured send-to-send, not receive-to-send.
+    (`_rate_limit_dir()`, under the resolved cache base). If less than the
+    required interval has passed, sleeps for the remaining time. The timestamp
+    is written at request start (before the HTTP call), so the interval is
+    measured send-to-send, not receive-to-send.
     Cache hits never reach this function — only real HTTP calls apply.
     """
-    min_interval = get_provider()["rate_limit"]
-    rl_file = _rate_limit_file()
+    provider = get_provider()
+    if _use_split_rate_limit(is_data):
+        min_interval = float(provider["data_rate_limit"])
+    else:
+        min_interval = provider["rate_limit"]
+    rl_file = _rate_limit_file(is_data)
     if rl_file.exists():
         try:
             last = float(rl_file.read_text().strip())
@@ -261,12 +277,15 @@ def sdmx_request(
     *,
     _timeout: float | None = None,
     _max_retries: int | None = None,
+    _is_data: bool = False,
     **params,
 ) -> httpx.Response:
     """Make a request to the active SDMX provider with retry logic.
 
     `_timeout` and `_max_retries` override the module defaults for this call only
     (used e.g. by `availableconstraint` discovery to fail fast on slow backends).
+    `_is_data=True` routes the call through the provider's `data_rate_limit` timer
+    (when configured), keeping data and structure calls on independent clocks.
     """
     url = f"{get_base_url()}/{path}"
     effective_timeout = _timeout if _timeout is not None else globals()["_timeout"]
@@ -283,14 +302,15 @@ def sdmx_request(
         # Hold an exclusive file lock for the whole HTTP call. This serializes
         # requests to the same provider across processes, so the rate limit is
         # actually enforced instead of being defeated by parallel reads of the
-        # timestamp file. Lock is per-provider, so different providers stay
-        # parallel. If the process dies, the kernel releases the flock.
-        with portalocker.Lock(str(_rate_limit_lock_file()), flags=portalocker.LOCK_EX):
-            _rate_limit_check()
+        # timestamp file. Lock is per-provider (and per-type when split), so
+        # different providers and data/structure streams stay parallel.
+        # If the process dies, the kernel releases the flock.
+        with portalocker.Lock(str(_rate_limit_lock_file(_is_data)), flags=portalocker.LOCK_EX):
+            _rate_limit_check(_is_data)
             # Record timestamp at request START (before HTTP call) so the
             # interval is measured send-to-send, not receive-to-send.
             try:
-                _rate_limit_file().write_text(str(time.time()))
+                _rate_limit_file(_is_data).write_text(str(time.time()))
             except OSError:
                 pass
             with httpx.Client(timeout=effective_timeout, follow_redirects=True) as client:
@@ -395,13 +415,13 @@ def sdmx_request_csv(path: str, **params):
                 ', '.join(dropped),
             )
         filtered_params = {k: v for k, v in params.items() if k not in unsupported}
-        resp = sdmx_request(path + suffix, accept=data_accept, **filtered_params)
+        resp = sdmx_request(path + suffix, accept=data_accept, _is_data=True, **filtered_params)
         import re
         text = re.sub(r"\[,", "[null,", resp.text)
         return _parse_sdmx_json(json.loads(text))
     elif fmt:
         # Provider requires a ?format= query param (e.g. Eurostat SDMX-CSV)
-        resp = sdmx_request(path, accept="application/xml", format=fmt, **params)
+        resp = sdmx_request(path, accept="application/xml", format=fmt, _is_data=True, **params)
     else:
-        resp = sdmx_request(path, accept="text/csv", **params)
+        resp = sdmx_request(path, accept="text/csv", _is_data=True, **params)
     return pl.read_csv(io.BytesIO(resp.content), infer_schema_length=10000, schema_overrides={"TIME_PERIOD": pl.Utf8, "OBS_VALUE": pl.Float64, "OBS_FLAG": pl.Utf8, "OBS_STATUS": pl.Utf8, "CONF_STATUS": pl.Utf8})

--- a/src/opensdmx/portals.json
+++ b/src/opensdmx/portals.json
@@ -59,6 +59,7 @@
     "agency_id": "OECD",
     "catalog_agency": "all",
     "constraint_params": {},
+    "data_rate_limit": 60,
     "constraints_supported": false,
     "last_n_supported": true,
     "categories_supported": true

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -15,6 +15,7 @@ from opensdmx.base import (
     sdmx_request,
     sdmx_request_csv,
     set_provider,
+    _use_split_rate_limit,
 )
 from opensdmx.discovery import all_available
 from opensdmx.retrieval import get_data
@@ -464,7 +465,7 @@ class TestAvailableConstraintTimeout:
         # Force db_cache to re-init schema for the per-test tmp cache dir.
         monkeypatch.setattr("opensdmx.db_cache._DB_INITIALIZED", False)
         # Skip per-provider rate-limit sleep so multi-attempt cases stay fast.
-        monkeypatch.setattr("opensdmx.base._rate_limit_check", lambda: None)
+        monkeypatch.setattr("opensdmx.base._rate_limit_check", lambda is_data=False: None)
 
     def _dataset(self, df_id: str = "TEST_DF") -> dict:
         return {
@@ -563,7 +564,7 @@ class TestConstraintEndpointPathBuild:
         from tenacity import wait_none
         monkeypatch.setattr("opensdmx.base.wait_exponential", lambda **kwargs: wait_none())
         monkeypatch.setattr("opensdmx.db_cache._DB_INITIALIZED", False)
-        monkeypatch.setattr("opensdmx.base._rate_limit_check", lambda: None)
+        monkeypatch.setattr("opensdmx.base._rate_limit_check", lambda is_data=False: None)
 
     @staticmethod
     def _dataset(df_id: str) -> dict:
@@ -607,3 +608,95 @@ class TestConstraintEndpointPathBuild:
 
         called_url = mock_client_class.return_value.get.call_args[0][0]
         assert "/contentconstraint/ESTAT/PRC_HICP_MANR" in called_url
+
+
+# ---------------------------------------------------------------------------
+# Split rate limiter (data_rate_limit)
+# ---------------------------------------------------------------------------
+
+class TestSplitRateLimit:
+    """Tests for per-provider data_rate_limit splitting data and structure timers."""
+
+    def test_no_split_for_provider_without_data_rate_limit(self):
+        """Provider without data_rate_limit never activates split path."""
+        set_provider("eurostat")  # no data_rate_limit
+        assert not _use_split_rate_limit(is_data=True)
+        assert not _use_split_rate_limit(is_data=False)
+
+    def test_split_active_for_provider_with_data_rate_limit(self):
+        """Provider with data_rate_limit activates split only for data calls."""
+        set_provider("oecd")  # data_rate_limit: 60
+        assert _use_split_rate_limit(is_data=True)
+        assert not _use_split_rate_limit(is_data=False)
+
+    def test_data_lock_file_differs_from_structure_lock_file(self, monkeypatch, tmp_path):
+        """When split is active, data and structure use different lock files."""
+        monkeypatch.setenv("OPENSDMX_CACHE_DIR", str(tmp_path))
+        from opensdmx.base import _resolve_cache_base_cached
+        _resolve_cache_base_cached.cache_clear()
+
+        set_provider("oecd")
+        struct_lock = _rate_limit_lock_file(is_data=False)
+        data_lock = _rate_limit_lock_file(is_data=True)
+        assert struct_lock != data_lock
+        assert struct_lock.name.endswith(".lock")
+        assert data_lock.name.endswith(".data.lock")
+
+    def test_no_split_same_lock_for_unified_provider(self, monkeypatch, tmp_path):
+        """Provider without data_rate_limit: data and structure share one lock file."""
+        monkeypatch.setenv("OPENSDMX_CACHE_DIR", str(tmp_path))
+        from opensdmx.base import _resolve_cache_base_cached
+        _resolve_cache_base_cached.cache_clear()
+
+        set_provider("eurostat")
+        struct_lock = _rate_limit_lock_file(is_data=False)
+        data_lock = _rate_limit_lock_file(is_data=True)
+        assert struct_lock == data_lock
+
+    def test_data_request_uses_data_lock(self, monkeypatch, tmp_path):
+        """sdmx_request_csv acquires the .data.lock file for providers with data_rate_limit."""
+        monkeypatch.setenv("OPENSDMX_CACHE_DIR", str(tmp_path))
+        from opensdmx.base import _resolve_cache_base_cached
+        _resolve_cache_base_cached.cache_clear()
+
+        set_provider("oecd")
+        expected_lock = str(_rate_limit_lock_file(is_data=True))
+
+        lock_cm = MagicMock()
+        lock_cm.__enter__ = MagicMock(return_value=lock_cm)
+        lock_cm.__exit__ = MagicMock(return_value=False)
+
+        with (
+            _mock_http_client(_CSV_CONTENT),
+            patch("opensdmx.base.portalocker.Lock", return_value=lock_cm) as mock_lock,
+        ):
+            sdmx_request_csv("data/OECD_DF")
+
+        called_path = mock_lock.call_args.args[0]
+        assert called_path == expected_lock
+        assert ".data.lock" in called_path
+
+    def test_structure_request_uses_plain_lock_even_for_split_provider(
+        self, monkeypatch, tmp_path
+    ):
+        """sdmx_request (structure) uses the plain .lock even when data_rate_limit is set."""
+        monkeypatch.setenv("OPENSDMX_CACHE_DIR", str(tmp_path))
+        from opensdmx.base import _resolve_cache_base_cached
+        _resolve_cache_base_cached.cache_clear()
+
+        set_provider("oecd")
+        plain_lock = str(_rate_limit_lock_file(is_data=False))
+
+        lock_cm = MagicMock()
+        lock_cm.__enter__ = MagicMock(return_value=lock_cm)
+        lock_cm.__exit__ = MagicMock(return_value=False)
+
+        with (
+            _mock_http_client(_CSV_CONTENT),
+            patch("opensdmx.base.portalocker.Lock", return_value=lock_cm) as mock_lock,
+        ):
+            sdmx_request("dataflow/OECD/all", accept="application/xml")
+
+        called_path = mock_lock.call_args.args[0]
+        assert called_path == plain_lock
+        assert ".data.lock" not in called_path


### PR DESCRIPTION
## Summary

- New `data_rate_limit` field in `portals.json`: when set, data calls (`/data/`) use an independent timer and lock file, while structure calls (dataflows, constraints, codelists) use the existing unified timer — no cross-blocking.
- Providers **without** `data_rate_limit` behave exactly as before (single unified timer/lock). Backward-compatible for ISTAT, Eurostat, Derzhstat, ECB, etc.
- OECD gets `data_rate_limit: 60` per [official docs](https://www.oecd.org/en/data/insights/data-explainers/2024/11/Api-best-practices-and-recommendations.html): 60 data downloads/hour. Structure calls (search, info, tree) are unthrottled.

## Implementation

- `_use_split_rate_limit(is_data)` — guard that enables the split path only when `data_rate_limit` is present
- `_rate_limit_file/lock_file/check` gain `is_data=False` param; split uses `.data.log`/`.data.lock` files
- `sdmx_request` gains `_is_data=False` kwarg propagated through to the rate-limit machinery
- All three data paths in `sdmx_request_csv` pass `_is_data=True`

## Test plan

- [x] `_use_split_rate_limit` returns False for providers without `data_rate_limit` (Eurostat)
- [x] `_use_split_rate_limit` returns True only for `is_data=True` on OECD
- [x] OECD data call acquires `.data.lock`, structure call acquires plain `.lock`
- [x] Eurostat: both call types share the same lock file (no change)
- [x] Existing timeout/retry/500 tests updated and passing
- [x] 165 tests pass

Closes #2