### PR TITLE
feat(istat): .Stat Suite hub fast path for get_available_values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ openspec/
 
 # Skill workspaces (local only)
 skills/*-workspace/
+
+# Playwright MCP browser cache (local only)
+.playwright-mcp/

--- a/LOG.md
+++ b/LOG.md
@@ -1,5 +1,30 @@
 # LOG
 
+## 2026-05-10 — v0.9.0: feat(istat): `.Stat Suite` hub fast path for `get_available_values`
+
+- feat(hub): new `src/opensdmx/hub.py` module wrapping the `.Stat Suite` databrowser hub
+  API (`/databrowserhub/api/core/nodes/{node}/datasets/{id}/column/{dim}/partial/values`).
+  Per-dimension JSON lookups in ~500 ms, never go through the slow
+  `availableconstraint`/`serieskeysonly` cross-join. Reference: `docs/istat/hub-api.md`.
+- feat(discovery): `get_available_values()` tries the hub right after the SQLite cache
+  and before the existing bulk + availableconstraint + serieskeysonly chain. Hub usage
+  is opt-in per provider via `hub_base_url` in `portals.json`; on any hub failure (HTTP
+  error, parse error, partial result) the original chain runs unchanged.
+- feat(portals): ISTAT gains `hub_base_url`, `hub_node_id`, `hub_dataset_agency`,
+  `hub_timeout`. No other provider is touched — Eurostat, OECD, ECB, ABS, BIS, IMF,
+  Bundesbank, INSEE, World Bank, Comext, Derzhstat all keep their existing path
+  byte-for-byte. `OPENSDMX_DISABLE_HUB=1` opts out at runtime.
+- fix(istat): `41_270_DF_DCIS_MORTIFERITISTR1_1` (11 dimensions, ~573 k observations)
+  now resolves all dimension values in ~7 s end-to-end. Previously: timeout on
+  `availableconstraint` after 30 s, timeout on `serieskeysonly` after 30 s, no usable
+  output. Verified live on 2026-05-10.
+- test: 19 new tests in `tests/test_hub.py` covering enable/disable, URL/identifier
+  build, JSON parsing, error fallback (HTTP error, timeout, malformed JSON, partial
+  failure), TIME_PERIOD exclusion, and discovery integration on both ISTAT-like and
+  non-hub providers. Two existing ISTAT regression tests in `test_http.py` opt out of
+  the hub explicitly so they keep guarding the SDMX-REST availableconstraint and bulk
+  contentconstraint codepaths. Total: 184 tests pass.
+
 ## 2026-05-10 — v0.8.0: feat: split rate limiter for data vs structure requests (issue #2)
 
 - feat(base): `_use_split_rate_limit(is_data)` — returns True only when `is_data=True` and the provider defines `data_rate_limit`. Keeps the unified timer for all providers without that key, preserving identical behavior for ISTAT, Eurostat, Derzhstat, and all others.

--- a/docs/istat/future-ideas.md
+++ b/docs/istat/future-ideas.md
@@ -1,0 +1,158 @@
+# Future ideas — faster ISTAT access via hub + SDMX REST
+
+This file collects ideas for combining the ISTAT hub API (`/databrowserhub/api/`) with the
+SDMX REST endpoint (`/SDMXWS/rest/`) to eliminate the performance problems described in
+`tmp/problemi_istat.md` and documented in `hub-api.md`.
+
+None of these are committed plans. They are design directions for discussion.
+
+---
+
+## The core opportunity
+
+The hub API and the SDMX REST endpoint are complementary:
+
+- **Hub**: fast catalog, fast dimension value discovery, no wildcards needed
+- **SDMX REST**: standard, cacheable, works perfectly with fully-specified keys
+
+The bottleneck today is value discovery. Replacing `availableconstraint` with
+`column/{DIM}/partial/values` removes the bottleneck entirely and makes even the most
+complex ISTAT datasets (11 dimensions, millions of observations) queryable in seconds.
+
+---
+
+## Idea 1 — hub as fallback for `get_available_values()`
+
+**Current fallback chain** in `discovery.py:get_available_values()`:
+
+```
+1. SQLite cache (7 days)
+2. availableconstraint  → 30s timeout on large datasets
+3. serieskeysonly       → timeout on 9+ dimensions
+4. codelist superset    → not implemented
+5. return {}            → user gets nothing
+```
+
+**Proposed chain with hub**:
+
+```
+1. SQLite cache (7 days)
+2. hub column/{DIM}/partial/values  → ~500ms, never times out
+3. availableconstraint              → kept as cross-check for non-ISTAT providers
+4. return {} with clear message
+```
+
+For ISTAT specifically, step 2 could be gated by a provider config flag
+(`hub_values_url`) so other providers are unaffected. The hub URL and node ID would
+be stored in the provider config.
+
+The result of step 2 is ground truth (not a theoretical codelist superset), so steps
+3–4 of the old chain become unnecessary for ISTAT.
+
+---
+
+## Idea 2 — hub-derived `source` field
+
+The `source` field discussed in issue #26 becomes straightforward once the hub is
+integrated. `get_available_values()` would return:
+
+```python
+{"dim_id": DataFrame, "source": "hub" | "constraint" | "serieskeysonly" | "cache"}
+```
+
+The CLI could surface this as:
+
+```
+RESULT   3 values  [source: hub]   M=morto  F=ferito  9=totale
+```
+
+This is low-effort once the hub call is in place.
+
+---
+
+## Idea 3 — hub catalog as primary catalog cache
+
+Today `opensdmx tree --provider istat` triggers a SDMX `categoryscheme` fetch (~24 MB,
+slow on first call). The hub `/catalog` endpoint returns the same hierarchy — 23 groups,
+849 categories, 3743 datasets — in a single fast call, already structured with
+`datasetIdentifiers` attached to each leaf.
+
+Replacing the SDMX categoryscheme fetch with the hub catalog would:
+
+- Eliminate the slow first-load for `tree`
+- Return `datasetIdentifiers` already associated to categories (no separate
+  `categorisation` parsing needed)
+- Keep the SDMX-native path as fallback for providers without a hub
+
+The hub catalog uses the same category IDs (`Z0810HEA`, `HEA_ROAD`) as the SDMX
+categoryscheme, so the rest of the tree navigation code would require minimal changes.
+
+---
+
+## Idea 4 — `opensdmx constraints` backed by hub for ISTAT
+
+`opensdmx constraints <df_id> --provider istat` currently fails silently on large
+datasets. With the hub, it could iterate over all dimensions via `column/{DIM}/partial/values`
+and return a complete constraints table — same output format, different data source.
+
+Since each dimension call is independent, they can run in parallel (subject to the ISTAT
+rate limit on the hub, which appears more permissive than the SDMX REST limit).
+
+This would make `opensdmx constraints` reliable for all ISTAT datasets without changing
+the user-facing interface.
+
+---
+
+## Idea 5 — hub POST `/data` as direct download path
+
+For small, targeted queries (e.g. last observation for a specific territory and
+indicator), the hub POST `/data` endpoint may be faster and simpler than constructing
+a full SDMX REST URL:
+
+```python
+# Instead of:
+curl ".../SDMXWS/rest/data/DF/A.015146.KILLINJ.M?lastNObservations=1"
+
+# Use:
+POST ".../databrowserhub/api/core/nodes/1/datasets/IT1,DF,1.0/data"
+body: [{FREQ:A}, {REF_AREA:015146}, {DATA_TYPE:KILLINJ}, {RESULT:M}, {TIME_PERIOD:last1}]
+```
+
+The response is a JSON-stat-like object rather than CSV/SDMX-XML, so it would require
+a dedicated parser. Worth evaluating for interactive use cases (skill queries, MCP tool
+responses) where a single value or small table is needed and CSV overhead is unnecessary.
+
+---
+
+## Idea 6 — `DF_BULK_*` surface in `opensdmx search`
+
+The hub catalog contains 80 `DF_BULK_*` datasets (identifiable by `obsCount: null`).
+These are pre-aggregated bulk downloads, not explorable via constraints. Currently they
+appear in search results but fail silently.
+
+Two options:
+- Filter them out of search results entirely
+- Label them explicitly: `[bulk download]` — user downloads as-is, no constraint
+  exploration
+
+The hub catalog makes this detection trivial at catalog-load time, with no additional
+API calls.
+
+---
+
+## Caveats and open questions
+
+- The hub API is `.Stat Suite`'s internal frontend API. It has no stability contract.
+  Any integration should degrade gracefully if the hub is unavailable (fall through to
+  the existing SDMX REST chain).
+- The `node/1` ID should be confirmed stable or made configurable in provider settings.
+- The `partial` segment in `column/{DIM}/partial/values` suggests pagination may exist.
+  Large dimensions (REF_AREA: 8716 codes) returned fully in one call, but this should
+  be tested with a deliberate page-size parameter to confirm there is no silent
+  truncation.
+- Hub rate limits: not characterised. The 5-dataflow test ran ~7 calls per dataflow
+  without throttling, but production use (iterating all dimensions, all datasets) should
+  be monitored.
+- If ISTAT upgrades to SDMX 3.0, the `schema` query with `referencepartial` would make
+  the hub workaround unnecessary. The hub integration should be designed as a temporary
+  bridge, not a permanent dependency.

--- a/docs/istat/hub-api.md
+++ b/docs/istat/hub-api.md
@@ -1,0 +1,306 @@
+# ISTAT Data Browser Hub API
+
+ISTAT's public web interface ([esploradati.istat.it](https://esploradati.istat.it)) is built
+on the [.Stat Suite](https://sis-cc.gitlab.io/dotstatsuite-documentation/) platform. The
+frontend communicates with a backend hub layer — `/databrowserhub/api/` — that is separate
+from the official SDMX 2.1 REST endpoint (`/SDMXWS/rest/`).
+
+> **Status**: this is the data browser's internal API. It is not an officially documented
+> public endpoint and carries no stability guarantee. Tested on 2026-05-10 against
+> `esploradati.istat.it`.
+
+The hub API is relevant because the SDMX REST `availableconstraint` endpoint times out on
+large Italian datasets (e.g. road accident statistics at province/municipality level), while
+the hub returns the same information in sub-second time.
+
+---
+
+## Base URL
+
+```
+https://esploradati.istat.it/databrowserhub/api/core/nodes/1
+```
+
+The `1` is the node ID observed in practice. It may vary across deployments.
+
+## Required headers
+
+```
+Accept: application/json
+userlang: it
+```
+
+No authentication is required.
+
+---
+
+## Endpoints
+
+### Catalog
+
+```
+GET /catalog
+```
+
+Returns the full thematic tree: category groups, nested categories, and dataset identifiers
+attached to each leaf.
+
+**Response structure**:
+
+```json
+{
+  "categoryGroups": [
+    {
+      "id": "IT1,Z0810HEA,1.0",
+      "label": "Salute e sanità",
+      "categories": [
+        {
+          "id": "HEA_ROAD",
+          "label": "Incidenti stradali",
+          "childrenCategories": [],
+          "datasetIdentifiers": [
+            "IT1,41_270_DF_DCIS_MORTIFERITISTR1_1,1.0",
+            "IT1,41_983_DF_DCIS_INCIDMORFER_COM_1,1.0"
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+Tested result: 23 top-level groups, 849 categories, 3743 dataset identifiers in a single call.
+
+---
+
+### Dataset structure
+
+```
+GET /datasets/{dataset_id}/structure
+```
+
+Where `{dataset_id}` is the full ISTAT identifier, e.g.
+`IT1,41_270_DF_DCIS_MORTIFERITISTR1_1,1.0`.
+
+Returns dimension IDs and labels. The dimension list matches the SDMX DSD, with `TIME_PERIOD`
+made explicit as an additional entry.
+
+**Response excerpt**:
+
+```json
+{
+  "criteria": [
+    {"id": "FREQ",     "label": "Frequenza"},
+    {"id": "REF_AREA", "label": "Territorio"},
+    {"id": "RESULT",   "label": "Esito"},
+    {"id": "TIME_PERIOD", "label": "Tempo"}
+  ],
+  "optimizedData": false
+}
+```
+
+---
+
+### Dimension values
+
+```
+GET /datasets/{dataset_id}/column/{dim_id}/partial/values
+```
+
+Returns the values **actually present** in the dataset for a given dimension, with Italian
+labels and total observation count. Responds in ~500ms even for `REF_AREA` with 8716 codes.
+
+The `partial` segment in the path suggests the endpoint may support pagination or filtering;
+this was not investigated.
+
+**Response structure**:
+
+```json
+{
+  "criteria": [
+    {
+      "id": "REF_AREA",
+      "values": [
+        {"id": "IT",     "name": "Italia",   "isDefault": false, "isSelectable": true},
+        {"id": "ITG12",  "name": "Palermo",  "isDefault": false, "isSelectable": true},
+        {"id": "015146", "name": "Milano",   "isDefault": false, "isSelectable": true}
+      ]
+    }
+  ],
+  "obsCount": 573552
+}
+```
+
+`obsCount` reflects the total number of observations in the dataset (not the dimension).
+Datasets with `obsCount: null` are bulk or glossary containers with no queryable data —
+about 80 of the 3743 entries in the catalog, identifiable by the `DF_BULK_` prefix in their
+ID.
+
+---
+
+### Data (filtered)
+
+```
+POST /datasets/{dataset_id}/data
+Content-Type: application/json
+```
+
+Request body: a JSON array of filter objects.
+
+```json
+[
+  {"id": "FREQ",        "filterValues": ["A"],      "type": "CodeValues", "period": 0},
+  {"id": "REF_AREA",    "filterValues": ["015146"], "type": "CodeValues", "period": 0},
+  {"id": "RESULT",      "filterValues": ["M"],      "type": "CodeValues", "period": 0},
+  {"id": "TIME_PERIOD", "type": "TimePeriod",        "period": 1, "filterValues": []}
+]
+```
+
+`"period": 1` on `TIME_PERIOD` requests the most recent period.
+
+**Response structure** (JSON-stat-like):
+
+```json
+{
+  "id":    ["FREQ", "REF_AREA", "DATA_TYPE", "RESULT", "TIME_PERIOD"],
+  "size":  [1, 1, 1, 1, 1],
+  "value": {"0": 22}
+}
+```
+
+Typical response time: ~466 ms (backend timer: ~186 ms).
+
+---
+
+## Worked examples
+
+### Fatal road accidents in Milan (municipality), 2024
+
+Dataset: `41_983_DF_DCIS_INCIDMORFER_COM_1` (Incidenti, morti e feriti — comuni)
+
+```bash
+# Step 1 — discover the Milano municipality code
+curl -s \
+  "https://esploradati.istat.it/databrowserhub/api/core/nodes/1/datasets/IT1,41_983_DF_DCIS_INCIDMORFER_COM_1,1.0/column/REF_AREA/partial/values" \
+  -H "userlang: it" -H "Accept: application/json" \
+  | jq -r '.criteria[0].values[] | select(.name | ascii_downcase | contains("milano")) | "\(.id)=\(.name)"'
+# → 015146=Milano  (municipality)
+# → ITC45=Milano   (province)
+
+# Step 2 — query the SDMX REST endpoint with a precise key
+# Dimension order from opensdmx info: FREQ · REF_AREA · DATA_TYPE · RESULT
+curl -s -H "Accept: text/csv" \
+  "https://esploradati.istat.it/SDMXWS/rest/data/41_983_DF_DCIS_INCIDMORFER_COM_1/A.015146.KILLINJ.M?lastNObservations=1"
+# → OBS_VALUE=38  (38 fatalities, Milan municipality, 2024)
+```
+
+---
+
+### Fatal road accidents in Palermo (province), 2024
+
+Dataset: `41_270_DF_DCIS_MORTIFERITISTR1_1` (Morti e feriti — 11 SDMX dimensions)
+
+This dataset causes timeouts on both `availableconstraint` and `serieskeysonly`. The hub
+returns all dimension values in sub-second time, enabling a precise SDMX REST query.
+
+```bash
+# Step 1 — get all dimension values via hub (run once per dimension)
+for DIM in FREQ REF_AREA DATA_TYPE ACCIDENT_LOCALIZATON INTERSECTION \
+           TY_ROAD_ACCIDENT RESULT PERSON_CLASS AGE SEX MONTH; do
+  echo "--- $DIM ---"
+  curl -s \
+    "https://esploradati.istat.it/databrowserhub/api/core/nodes/1/datasets/IT1,41_270_DF_DCIS_MORTIFERITISTR1_1,1.0/column/$DIM/partial/values" \
+    -H "userlang: it" -H "Accept: application/json" \
+    | jq -r '.criteria[0].values[] | "\(.id)=\(.name)"'
+done
+
+# Aggregate codes found:
+#   ACCIDENT_LOCALIZATON=9 (totale), INTERSECTION=9, TY_ROAD_ACCIDENT=9
+#   RESULT=M (morto), PERSON_CLASS=9, AGE=TOTAL, SEX=9, MONTH=99
+
+# Step 2 — SDMX REST with fully specified 11-dimension key
+# Dimension order: FREQ · REF_AREA · DATA_TYPE · ACCIDENT_LOCALIZATON · INTERSECTION
+#                  · TY_ROAD_ACCIDENT · RESULT · PERSON_CLASS · AGE · SEX · MONTH
+curl -s -H "Accept: text/csv" \
+  "https://esploradati.istat.it/SDMXWS/rest/data/41_270_DF_DCIS_MORTIFERITISTR1_1/A.ITG12.KILLINJ.9.9.9.M.9.TOTAL.9.99?lastNObservations=1"
+# → OBS_VALUE=55  (55 fatalities, Palermo province, 2024)
+```
+
+The same query via `opensdmx get` without explicit codes timed out after 15+ minutes.
+The precise-key SDMX REST call returned in under 5 seconds.
+
+---
+
+## Relationship with the SDMX REST endpoint
+
+The hub API and the SDMX REST endpoint (`/SDMXWS/rest/`) serve different roles:
+
+| Operation | SDMX REST | Hub API |
+|---|---|---|
+| Dataset catalog | `categoryscheme` (~24 MB, slow) | `GET /catalog` (single call, fast) |
+| Dimension values | `availableconstraint` (timeouts on large datasets) | `GET /column/{DIM}/partial/values` (sub-second) |
+| Data download | `GET /data/{key}` (works well with precise keys) | `POST /data` (JSON body, ~466ms) |
+
+For value discovery on ISTAT, `column/{DIM}/partial/values` is a practical alternative to
+`availableconstraint` when the latter times out.
+
+---
+
+## Why the hub solves the `41_270` timeout problem
+
+`41_270_DF_DCIS_MORTIFERITISTR1_1` (morti e feriti in incidenti stradali) has 11 SDMX
+dimensions. Any SDMX REST query that leaves even one dimension as a wildcard triggers a
+server-side cartesian product that the backend cannot complete within any practical timeout.
+
+### What fails and why
+
+The standard discovery flow on ISTAT uses `availableconstraint` to retrieve the codes
+actually present in the dataset before building a query. For `41_270`, this endpoint never
+responds — it times out after 30+ seconds with zero bytes received. The automatic fallback
+to `data?detail=serieskeysonly` also times out, because the server has to enumerate all
+valid series keys across 11 dimensions. A probe `GET` with partial wildcards (tested with
+`--REF_AREA 082053 --RESULT M`, nine other dimensions left as `.`) also timed out after
+over 15 minutes in two independent tests.
+
+The root cause is server-side: ISTAT's SDMX endpoint executes a full cross-join across
+all unspecified dimensions before filtering. With 11 dimensions the search space is too
+large regardless of how tight the specified filters are.
+
+### Why the hub does not have this problem
+
+The hub `column/{DIM}/partial/values` endpoint returns the valid values for **one
+dimension at a time**, independently of the others. There is no cross-join. Each call
+costs ~500–650 ms regardless of dataset size or dimension count. For `41_270`:
+
+```
+11 dimensions × ~600 ms each ≈ 6.6 s total discovery time
+```
+
+versus the SDMX REST `availableconstraint` approach: **no response at all**.
+
+### The resulting workflow
+
+Once all dimension values are known, the SDMX REST data endpoint works fine — it is only
+slow when wildcards force a server-side enumeration. A fully specified 11-dimension key
+returns in under 5 seconds:
+
+```
+A.ITG12.KILLINJ.9.9.9.M.9.TOTAL.9.99
+└─┬──┘ └─┬───┘ └──┬──┘ └┬┘ └┬┘ └┬┘ └┬┘ └─┬─┘└──┬──┘ └┬┘ └┬─┘
+  A    Palermo  KILLINJ  9   9   9  M   9  TOTAL  9   99
+FREQ  REF_AREA  DATA_TY  LOC INT TYP RES PERSON AGE  SEX MON
+```
+
+Result: `OBS_VALUE=55` (55 fatalities, Palermo province, 2024) — from a query that
+previously produced only timeouts.
+
+The key insight is that the SDMX REST data endpoint is not slow; the bottleneck is
+**value discovery**. The hub eliminates that bottleneck entirely.
+
+---
+
+## References
+
+- [.Stat Suite documentation](https://sis-cc.gitlab.io/dotstatsuite-documentation/using-api/data/)
+- ISTAT SDMX API guide: [ondata.github.io/guida-api-istat](https://ondata.github.io/guida-api-istat)
+- `tmp/problemi_istat.md` — diagnosis and timeline of SDMX REST timeout issues

--- a/skills/sdmx-explorer/SKILL.md
+++ b/skills/sdmx-explorer/SKILL.md
@@ -352,14 +352,20 @@ opensdmx constraints DF_LABOR_FORCE_A REGION --provider derzhstat
 # → 28 KATOTTG codes, each with the Ukrainian region name
 ```
 
-`opensdmx constraints` is the ground truth — it queries the SDMX constraint
-endpoint (`contentconstraint` for Eurostat and ISTAT, `availableconstraint`
-for the others) and returns only codes that actually exist in this specific
-dataflow.
+`opensdmx constraints` is the ground truth — it queries the best discovery
+endpoint available for the active provider and returns only codes that
+actually exist in this specific dataflow:
 
-**Missing dimensions.** Providers on `contentconstraint` may omit large
-dimensions (e.g. ISTAT does not expose `REF_AREA`, ~8,000 comuni). The CLI
-flags these inline:
+- **ISTAT** — the `.Stat Suite` databrowser hub, which returns ground-truth
+  values per dimension in sub-second time. Every dimension is exposed,
+  including `REF_AREA` (~8,000 comuni). Set `OPENSDMX_DISABLE_HUB=1` to fall
+  back to `contentconstraint`/`availableconstraint`.
+- **Eurostat** — `contentconstraint`.
+- **All others** — `availableconstraint` (or the provider-specific equivalent).
+
+**Missing dimensions** are now rare. They appear only on providers/datasets
+where the discovery endpoint does not list a particular dimension (e.g. some
+Eurostat dataflows). The CLI flags these inline:
 
 ```
 REF_AREA  –  not in contentconstraint — use: opensdmx values <df> REF_AREA
@@ -399,8 +405,10 @@ opensdmx --output json constraints PRC_HICP_MANR | jq '.geo.codes'
 # number of values per dimension (only those exposed by constraint)
 opensdmx --output json constraints PRC_HICP_MANR | jq 'to_entries[] | select(.value.source=="constraint") | {dim: .key, n: .value.n_values}'
 
-# list dimensions missing from contentconstraint (need a follow-up `values` call)
-opensdmx --output json constraints 22_289_DF_DCIS_POPRES1_24 --provider istat | jq 'to_entries[] | select(.value.source=="missing") | {dim: .key, hint: .value.hint}'
+# list dimensions missing from the discovery endpoint (need a follow-up `values` call)
+# Note: for ISTAT this returns nothing — the hub exposes every dimension. Useful on
+# Eurostat dataflows where contentconstraint occasionally omits large geo lists.
+opensdmx --output json constraints NAMA_10_GDP --provider eurostat | jq 'to_entries[] | select(.value.source=="missing") | {dim: .key, hint: .value.hint}'
 
 # find a code by label (case-insensitive)
 opensdmx --output json constraints PRC_HICP_MANR coicop | jq '[.[] | select(.name | ascii_downcase | contains("food"))]'
@@ -421,13 +429,18 @@ may return no data if it doesn't exist in this specific dataflow.
 
 ### ISTAT flow
 
-ISTAT requires a different exploration pattern: the API has a strict ~13 s rate
-limit, codelists and constraints diverge often, and some codes carry version
-suffixes that need stripping. The flow consolidates `info` → `values` →
-`constraints` (mandatory before `get`) → `get`.
+ISTAT keeps the `info` → `constraints` → `get` shape, with `values` as an
+optional sidecar for code labels. The SDMX REST endpoint has a strict ~13 s
+rate limit, but `opensdmx constraints` for ISTAT now goes through the
+`.Stat Suite` databrowser hub: every dimension (including `REF_AREA` with
+~8,000 comuni) is returned in sub-second time, even on 11-dimension
+datasets that previously timed out on `availableconstraint`. Some codes
+still carry version/date suffixes (`LBIRTH_FROM2017`, `POP_1JAN2021`) that
+may need stripping when filtering.
 
-For the full step-by-step walkthrough, territory codes, and ISTAT-specific
-quirks, see [references/istat-flow.md](references/istat-flow.md).
+For the full step-by-step walkthrough, territory codes, the hub fast path,
+the legacy SDMX REST fallback, and ISTAT-specific quirks, see
+[references/istat-flow.md](references/istat-flow.md).
 
 ### Extract from both flows
 

--- a/skills/sdmx-explorer/references/istat-flow.md
+++ b/skills/sdmx-explorer/references/istat-flow.md
@@ -4,15 +4,24 @@ ISTAT (Italian National Institute of Statistics) is the canonical SDMX source
 for Italian statistics. Its API behaves differently from Eurostat in three ways
 that shape the entire exploration flow:
 
-1. **Strict rate limit (~13 s between requests)** — every wasted call costs real
-   time, so verifying codes upfront is much cheaper than trial-and-error `get`.
-2. **`constraints` uses `contentconstraint` (sub-second)** — fast, reliable, but
-   does **not** expose `REF_AREA` (geographic dimension). For municipal datasets
-   that's by design: 8,000+ comuni would inflate the payload. The CLI surfaces
-   the missing dimension with an inline hint to `opensdmx values`.
+1. **Strict rate limit (~13 s between requests)** on the SDMX REST endpoint —
+   every wasted `get` costs real time, so verifying codes upfront is much
+   cheaper than trial-and-error.
+2. **Hub-backed `constraints` (sub-second per dimension)** — for ISTAT,
+   `opensdmx constraints` uses the `.Stat Suite` databrowser hub by default and
+   returns ground-truth values for **every** dimension, including `REF_AREA`
+   (~8,000 comuni) and even on 11-dimension datasets that previously timed out
+   on the SDMX REST endpoint. No wildcard cross-join, no 30 s waits.
 3. **Versioned/dated codes** — some codes carry suffixes (`LBIRTH_FROM2017`,
    `POP_1JAN2021`) that may need to be stripped to match what the dataflow
    actually accepts.
+
+> **Hub note.** The hub call is automatic and transparent. On any hub failure
+> (network error, parse error, partial response) the CLI falls through to the
+> classic SDMX REST chain (`contentconstraint` bulk → `availableconstraint` →
+> `serieskeysonly`) without warning. Set `OPENSDMX_DISABLE_HUB=1` to force the
+> SDMX REST path for debugging or comparison. See `docs/istat/hub-api.md` for
+> the protocol details.
 
 ## Standard exploration flow
 
@@ -25,50 +34,40 @@ opensdmx info <dataflow_id> --provider istat
 Note dimension flags: ISTAT uses **uppercase** (`--REF_AREA`, `--DATA_TYPE`,
 `--FREQ`), unlike Eurostat (lowercase).
 
-### Step 2 — call `constraints` first
+### Step 2 — call `constraints` (one stop)
 
 ```bash
 opensdmx constraints <dataflow_id> --provider istat
 ```
 
-`contentconstraint` returns sub-second, so this is the cheapest first call
-to make. The output looks like:
+For ISTAT, `constraints` resolves every dimension via the hub in roughly
+500 ms per dimension. The output is ground truth — the codes actually present
+in the dataflow, not the theoretical codelist superset.
 
 ```
-Constraints: 22_289_DF_DCIS_POPRES1_24
-  FREQ            1   A
-  REF_AREA        –   not in contentconstraint — use: opensdmx values 22_289_DF_DCIS_POPRES1_24 REF_AREA
-  DATA_TYPE       1   JAN
-  SEX             3   1, 2, 9
-  AGE           102   TOTAL, Y_GE100, Y0
-  MARITAL_STATUS  1   99
+Constraints: 41_270_DF_DCIS_MORTIFERITISTR1_1
+  FREQ                1   A
+  REF_AREA          179   IT111, IT, ITC
+  DATA_TYPE           1   KILLINJ
+  ACCIDENT_LOCALIZATON 4  1, 2, 3
+  RESULT              3   M, F, 9
+  AGE                14   Y_UN5, Y6-9, Y10-14
+  SEX                 3   1, 2, 9
+  MONTH              13   1, 2, 3
+  …
 ```
 
-For the dimensions present (`FREQ`, `DATA_TYPE`, `SEX`, `AGE`,
-`MARITAL_STATUS`) you have ground truth: the codes really present in the
-dataflow. For any dimension marked `–` ("not in contentconstraint"), the CLI
-tells you exactly which command to run next.
+`REF_AREA` is now exposed alongside every other dimension. For the few
+historical cases where it was returned with a `–` placeholder (hub disabled,
+hub unreachable, very old cached entries), follow the legacy fallback in
+[Step 2b](#step-2b--legacy-fallback-when-the-hub-is-unavailable) below.
 
-### Step 2b — When `contentconstraint` returns 404
+### Step 2b — Legacy fallback when the hub is unavailable
 
-Some ISTAT datasets do not publish a `contentconstraint`. When this happens,
-`opensdmx constraints` automatically falls back to `availableconstraint`
-(the endpoint that returns values actually present in the data). The fallback
-uses a 30 s timeout to fail fast on slow backends.
-
-**Most datasets**: the automatic fallback succeeds silently — you get constraint
-data without any extra steps.
-
-**Large municipal datasets** (e.g. road accidents, detailed demographic flows):
-`availableconstraint` may time out even with the automatic fallback, because the
-endpoint itself is unresponsive on very large datasets. In that case `opensdmx
-constraints` raises a timeout error with a clear message. Continue with Fallback
-B below.
-
-**Fallback B — probe GET to discover valid territory codes**
-
-When the automatic fallback times out, do a probe GET with no area filter and a
-narrow 1-year time range. Save to CSV and inspect distinct values:
+If you see a `–` ("not in contentconstraint") in the output for a dimension,
+or if you have set `OPENSDMX_DISABLE_HUB=1` and a dataset happens to time out
+on `availableconstraint`, fall back to a probe GET with no area filter and a
+narrow 1-year time range:
 
 ```bash
 opensdmx get <dataflow_id> --provider istat \
@@ -79,39 +78,23 @@ duckdb -c "SELECT DISTINCT REF_AREA, count(*) n FROM '/tmp/probe.csv' GROUP BY R
 ```
 
 This is slower (full-year scan) but gives ground truth on which `REF_AREA`
-codes are actually populated in the dataflow.
+codes are actually populated in the dataflow. If even this returns no results,
+the dataset may need a different aggregation: run `opensdmx siblings
+<dataflow_id> --provider istat` and verify via I.Stat that the data exists at
+the requested granularity.
 
-**If Fallback B also times out or returns no results**
+### Step 3 — `values` for code labels (optional)
 
-The dataset may have issues specific to the SDMX REST endpoint:
-
-1. Check if the search results included region-specific variants (e.g.
-   `41_269_1` for Lazio) — the data may be published per-region.
-2. Run `opensdmx siblings <dataflow_id> --provider istat` to find related
-   dataflows that may cover the same subject at a different aggregation level.
-3. Verify via the ISTAT web explorer (I.Stat) that the data exists at the
-   requested granularity.
-
-### Step 3 — for missing dimensions, fall back to `values`
-
-```bash
-opensdmx values <dataflow_id> REF_AREA --provider istat
-```
-
-`values` returns the **theoretical codelist**. For `REF_AREA` (`CL_ITTER107`)
-that's all 8,000+ Italian territory codes — comuni, province, regioni,
-aggregati statistici (`ITG12`, `SLL_*`, etc.). Filter with `grep -i` to find
-candidates:
+`opensdmx constraints` already returns the IDs you need. Use `opensdmx values`
+only when you also want the human-readable label of a specific code:
 
 ```bash
 opensdmx values <dataflow_id> REF_AREA --provider istat 2>&1 | grep -i "palermo"
 ```
 
-Caveat: `values` is the universe of codes the codelist defines, **not** the
-codes actually populated in the dataflow. Most municipal codes work, but some
-versioned variants (`POP_1JAN2021`) appear in the codelist while the dataflow
-only accepts the base form. If a `get` returns 404 / `NoRecordsFound`, try
-the base code or check whether the suffix matches the year you're querying.
+Caveat: `values` is the **theoretical codelist** (universe of codes the
+codelist defines), not necessarily the codes populated in this dataflow. Trust
+`constraints` for what works, `values` for labels.
 
 ### Step 4 — build the query using verified codes
 
@@ -139,8 +122,10 @@ ISTAT uses numeric `REF_AREA` codes:
 - Aggregate codes (`ITG12` for groups of provinces, `SLL_*` for labour market
   areas, etc.)
 
-`REF_AREA` is the dimension `contentconstraint` does not expose — always go
-through `opensdmx values <df> REF_AREA --provider istat` to discover codes.
+For ISTAT, `REF_AREA` is exposed by `opensdmx constraints` via the hub — start
+there. Use `opensdmx values <df> REF_AREA --provider istat` only when you need
+the full theoretical codelist (e.g. mapping a specific code to its readable
+label) or when running with the hub disabled.
 
 ## Direct download URL pattern
 

--- a/skills/sdmx-explorer/references/providers.md
+++ b/skills/sdmx-explorer/references/providers.md
@@ -8,8 +8,9 @@ flow fits the target provider.
 For flows that deviate substantially from the default pattern, see the dedicated
 references:
 
-- **ISTAT** (rate limit, suffix patterns, territory codes, mandatory `constraints`
-  step): [istat-flow.md](istat-flow.md)
+- **ISTAT** (rate limit, suffix patterns, territory codes, hub-backed
+  `constraints` for ground-truth dimension values incl. `REF_AREA`):
+  [istat-flow.md](istat-flow.md)
 - **World Bank** (single-dataflow architecture, alpha-3 codes, known bug):
   [worldbank-flow.md](worldbank-flow.md)
 
@@ -18,7 +19,7 @@ references:
 | Provider | constraints | last_n | Notes |
 |----------|:-----------:|:------:|-------|
 | Eurostat | ✓ | ✓ | **Default provider** (no `--provider` flag needed); dimension flags are lowercase (`--geo`, `--coicop`); country codes: ISO 3166-1 alpha-2 + EU aggregates like `EU27_2020` |
-| ISTAT | ✓ | ✓ | Use `--provider istat`; dedicated reference: [istat-flow.md](istat-flow.md) |
+| ISTAT | ✓ | ✓ | Use `--provider istat`; `constraints` uses the `.Stat Suite` hub by default — sub-second per dimension, exposes every dim including `REF_AREA`. Dedicated reference: [istat-flow.md](istat-flow.md) |
 | ECB | ✗ | ✓ | Use `--provider ecb`; financial and monetary data; skip `opensdmx constraints`, use `opensdmx values` to explore codelists |
 | OECD | ✗ | ✓ | Use `--provider oecd`; good for international comparisons; skip `opensdmx constraints`, use `opensdmx values` + probe `get` instead |
 | INSEE | ✗ | ✓ | Use `--provider insee`; French macroeconomic time series (BDM database) |

--- a/src/opensdmx/discovery.py
+++ b/src/opensdmx/discovery.py
@@ -634,12 +634,17 @@ def _fetch_and_cache_bulk_constraints(agency_id: str) -> set[str]:
 def get_available_values(dataset: dict) -> dict[str, pl.DataFrame]:
     """Get all available values for all dimensions via constraint endpoint.
 
-    For providers with constraint_bulk_supported: fetches the full constraint
-    catalog in one call and uses it directly, avoiding per-dataflow 404 roundtrips.
-    For providers using contentconstraint without bulk support: falls back to
-    availableconstraint when contentconstraint returns 404.
+    Resolution order:
+      1. SQLite cache (7 days)
+      2. `.Stat Suite` hub, when configured (currently ISTAT) — per-dimension
+         ground truth, sub-second per call, never times out on large datasets
+      3. Bulk contentconstraint catalog when `constraint_bulk_supported`
+      4. Per-dataflow contentconstraint / availableconstraint
+      5. `data?detail=serieskeysonly` fallback
 
-    Results are cached in SQLite for 7 days.
+    Steps 2+ are gated by provider config: providers without `hub_base_url`
+    skip step 2; providers without `constraint_bulk_supported` skip step 3.
+    Hub failures fall through transparently to the existing chain.
     """
     from .db_cache import get_cached_available_constraints, save_available_constraints
 
@@ -649,6 +654,22 @@ def get_available_values(dataset: dict) -> dict[str, pl.DataFrame]:
         return {dim_id: pl.DataFrame({"id": codes}) for dim_id, codes in cached.items()}
 
     provider = get_provider()
+
+    # `.Stat Suite` hub fast path: opt-in via provider config (`hub_base_url`).
+    # Skipped entirely for non-hub providers (Eurostat, OECD, ECB, ...). On any
+    # hub failure, falls through to the existing SDMX REST chain unchanged.
+    # Pass the patched provider explicitly so test patches on get_provider
+    # control hub activation deterministically.
+    from .hub import is_hub_enabled, get_available_values_via_hub
+    if is_hub_enabled(provider):
+        hub_result = get_available_values_via_hub(dataset)
+        if hub_result:
+            try:
+                save_available_constraints(df_id, hub_result)
+            except Exception as e:
+                logger.warning("Could not cache hub-derived constraints: %s", e)
+            return {dim_id: pl.DataFrame({"id": codes}) for dim_id, codes in hub_result.items()}
+
     constraint_endpoint = provider.get("constraint_endpoint", "availableconstraint")
     constraint_suffix = provider.get("constraint_path_suffix", "")
 

--- a/src/opensdmx/discovery.py
+++ b/src/opensdmx/discovery.py
@@ -637,7 +637,9 @@ def get_available_values(dataset: dict) -> dict[str, pl.DataFrame]:
     Resolution order:
       1. SQLite cache (7 days)
       2. `.Stat Suite` hub, when configured (currently ISTAT) — per-dimension
-         ground truth, sub-second per call, never times out on large datasets
+         ground truth, typically sub-second per call, sidesteps the SDMX-REST
+         `availableconstraint` timeout pattern on large datasets (still bounded
+         by `hub_timeout`; on any failure falls through to step 3)
       3. Bulk contentconstraint catalog when `constraint_bulk_supported`
       4. Per-dataflow contentconstraint / availableconstraint
       5. `data?detail=serieskeysonly` fallback

--- a/src/opensdmx/hub.py
+++ b/src/opensdmx/hub.py
@@ -1,0 +1,155 @@
+"""Optional .Stat Suite hub integration (ISTAT-style providers).
+
+Some SDMX providers — currently ISTAT — expose a `.Stat Suite` hub API alongside
+the official SDMX 2.1 REST endpoint. The hub serves the same data through faster,
+more focused endpoints (single-dimension value lookups, JSON catalog) and is the
+backend behind the public databrowser UI.
+
+This module is opt-in per provider via `portals.json`:
+
+    "hub_base_url":     "https://esploradati.istat.it/databrowserhub/api/core"
+    "hub_node_id":      "1"
+    "hub_dataset_agency": "IT1"        # optional; defaults to provider agency_id
+    "hub_timeout":      15.0           # optional; defaults to 15s
+
+Providers without `hub_base_url` are unaffected by this module.
+
+All hub calls degrade gracefully: any HTTP/parse error returns an empty result so
+the caller falls through to the standard SDMX REST chain. The hub is an optimization,
+never a hard requirement.
+
+Reference: docs/istat/hub-api.md
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+
+import httpx
+
+from .base import get_provider
+
+logger = logging.getLogger(__name__)
+
+
+def is_hub_enabled(provider: dict | None = None) -> bool:
+    """True when the active provider exposes a `.Stat Suite` hub.
+
+    Pass an explicit `provider` dict to make the check independent of the
+    module-level provider state (useful in tests where the caller already
+    holds a patched provider dict). When omitted, reads the active provider.
+
+    Honors `OPENSDMX_DISABLE_HUB=1` for emergency opt-out without code changes.
+    """
+    if os.environ.get("OPENSDMX_DISABLE_HUB"):
+        return False
+    p = provider if provider is not None else get_provider()
+    return bool(p.get("hub_base_url"))
+
+
+def _hub_node_url() -> str:
+    """Return the per-node hub root: `{hub_base_url}/nodes/{hub_node_id}`."""
+    p = get_provider()
+    base = p["hub_base_url"].rstrip("/")
+    node = str(p.get("hub_node_id", "1"))
+    return f"{base}/nodes/{node}"
+
+
+def _dataset_identifier(df_id: str, version: str | None) -> str:
+    """Build the hub dataset identifier `{agency},{df_id},{version}`.
+
+    Uses `hub_dataset_agency` from provider config, falling back to `agency_id`.
+    Version defaults to `1.0` when missing.
+    """
+    p = get_provider()
+    agency = p.get("hub_dataset_agency") or p["agency_id"]
+    v = version or "1.0"
+    return f"{agency},{df_id},{v}"
+
+
+def _hub_get_json(path: str, timeout: float) -> dict | None:
+    """GET a hub path and return parsed JSON, or `None` on any error.
+
+    Errors are logged at WARNING and never propagate — callers must fall through
+    to the existing SDMX REST chain whenever this returns None.
+    """
+    url = f"{_hub_node_url()}/{path.lstrip('/')}"
+    p = get_provider()
+    user_agent = (
+        os.environ.get("OPENSDMX_USER_AGENT")
+        or p.get("user_agent")
+        or "opensdmx Python package"
+    )
+    headers = {
+        "Accept": "application/json",
+        "userlang": p.get("language", "en"),
+        "User-Agent": user_agent,
+    }
+    try:
+        with httpx.Client(timeout=timeout, follow_redirects=True) as client:
+            resp = client.get(url, headers=headers)
+            resp.raise_for_status()
+            return resp.json()
+    except (httpx.HTTPError, json.JSONDecodeError, ValueError) as e:
+        logger.warning("hub request failed for %s: %s", path, e)
+        return None
+
+
+def get_dimension_values_via_hub(
+    df_id: str,
+    dim_id: str,
+    version: str | None = None,
+    *,
+    timeout: float | None = None,
+) -> list[str]:
+    """Return the code IDs available for `dim_id` in `df_id`, via hub.
+
+    Returns `[]` on any error. The hub returns ground-truth values present in
+    the dataset (not the codelist superset).
+    """
+    p = get_provider()
+    effective_timeout = float(timeout if timeout is not None else p.get("hub_timeout", 15.0))
+    ds_id = _dataset_identifier(df_id, version)
+    path = f"datasets/{ds_id}/column/{dim_id}/partial/values"
+    payload = _hub_get_json(path, effective_timeout)
+    if not payload:
+        return []
+    try:
+        criteria = payload["criteria"][0]
+        return [v["id"] for v in criteria.get("values", []) if v.get("id")]
+    except (KeyError, IndexError, TypeError) as e:
+        logger.warning(
+            "hub returned unexpected JSON shape for %s/%s: %s", df_id, dim_id, e
+        )
+        return []
+
+
+def get_available_values_via_hub(dataset: dict) -> dict[str, list[str]]:
+    """Return `{dim_id: [codes]}` for every codelist dimension via hub.
+
+    Iterates the dataset's dimensions sequentially. Returns `{}` if any
+    dimension call fails — partial results would mislead the caller into
+    skipping the SDMX-REST fallback. TIME_PERIOD is excluded (it is a
+    `TimeDimension` in the DSD and is normally not in `dataset["dimensions"]`,
+    but we filter defensively).
+    """
+    df_id = dataset["df_id"]
+    version = dataset.get("version")
+    dim_ids = [d for d in dataset.get("dimensions", {}) if d.upper() != "TIME_PERIOD"]
+    if not dim_ids:
+        return {}
+
+    result: dict[str, list[str]] = {}
+    for dim_id in dim_ids:
+        codes = get_dimension_values_via_hub(df_id, dim_id, version=version)
+        if not codes:
+            logger.warning(
+                "hub returned no values for dimension %s of %s — aborting hub discovery",
+                dim_id,
+                df_id,
+            )
+            return {}
+        result[dim_id] = codes
+    return result

--- a/src/opensdmx/hub.py
+++ b/src/opensdmx/hub.py
@@ -106,10 +106,15 @@ def get_dimension_values_via_hub(
 ) -> list[str]:
     """Return the code IDs available for `dim_id` in `df_id`, via hub.
 
-    Returns `[]` on any error. The hub returns ground-truth values present in
-    the dataset (not the codelist superset).
+    Returns `[]` on any error, including when the active provider has no
+    `hub_base_url` configured — the module's "fails gracefully" contract holds
+    even if callers invoke this function without first checking
+    `is_hub_enabled()`. The hub returns ground-truth values present in the
+    dataset (not the codelist superset).
     """
     p = get_provider()
+    if not p.get("hub_base_url"):
+        return []
     effective_timeout = float(timeout if timeout is not None else p.get("hub_timeout", 15.0))
     ds_id = _dataset_identifier(df_id, version)
     path = f"datasets/{ds_id}/column/{dim_id}/partial/values"
@@ -129,12 +134,16 @@ def get_dimension_values_via_hub(
 def get_available_values_via_hub(dataset: dict) -> dict[str, list[str]]:
     """Return `{dim_id: [codes]}` for every codelist dimension via hub.
 
-    Iterates the dataset's dimensions sequentially. Returns `{}` if any
-    dimension call fails — partial results would mislead the caller into
-    skipping the SDMX-REST fallback. TIME_PERIOD is excluded (it is a
-    `TimeDimension` in the DSD and is normally not in `dataset["dimensions"]`,
-    but we filter defensively).
+    Iterates the dataset's dimensions sequentially. Returns `{}` on any
+    failure — including when the active provider has no `hub_base_url`
+    configured — so callers fall through to the SDMX-REST chain. Partial
+    results would mislead the caller into skipping the fallback, so any
+    dimension miss aborts the whole hub attempt. TIME_PERIOD is excluded
+    (it is a `TimeDimension` in the DSD and is normally not in
+    `dataset["dimensions"]`, but we filter defensively).
     """
+    if not get_provider().get("hub_base_url"):
+        return {}
     df_id = dataset["df_id"]
     version = dataset.get("version")
     dim_ids = [d for d in dataset.get("dimensions", {}) if d.upper() != "TIME_PERIOD"]

--- a/src/opensdmx/portals.json
+++ b/src/opensdmx/portals.json
@@ -41,7 +41,11 @@
     "constraint_fallback_timeout": 30,
     "constraints_supported": true,
     "last_n_supported": true,
-    "categories_supported": true
+    "categories_supported": true,
+    "hub_base_url": "https://esploradati.istat.it/databrowserhub/api/core",
+    "hub_node_id": "1",
+    "hub_dataset_agency": "IT1",
+    "hub_timeout": 15.0
   },
   "ecb": {
     "name": "European Central Bank",

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -488,6 +488,9 @@ class TestAvailableConstraintTimeout:
         from opensdmx.discovery import ConstraintsTimeout, get_available_values
 
         monkeypatch.setenv("OPENSDMX_CACHE_DIR", str(tmp_path))
+        # Hub is on by default for ISTAT; this test exercises the SDMX-REST
+        # availableconstraint path explicitly, so we opt out of the hub.
+        monkeypatch.setenv("OPENSDMX_DISABLE_HUB", "1")
         monkeypatch.setitem(PROVIDERS["istat"], "constraint_timeout", 30)
         monkeypatch.setitem(PROVIDERS["istat"], "constraint_max_retries", 1)
         monkeypatch.setitem(PROVIDERS["istat"], "constraint_endpoint", "availableconstraint")
@@ -508,6 +511,10 @@ class TestAvailableConstraintTimeout:
 
         monkeypatch.setenv("OPENSDMX_CACHE_DIR", str(tmp_path))
         monkeypatch.setenv("OPENSDMX_AVAILCONSTRAINT_TIMEOUT", "12.0")
+        # This test exercises the SDMX-REST availableconstraint timeout path;
+        # ISTAT's hub would otherwise be tried first (and also fail), polluting
+        # call counts and the recorded timeout. Force the hub off.
+        monkeypatch.setenv("OPENSDMX_DISABLE_HUB", "1")
         monkeypatch.setitem(PROVIDERS["istat"], "constraint_timeout", 30)
         monkeypatch.setitem(PROVIDERS["istat"], "constraint_max_retries", 1)
         monkeypatch.setitem(PROVIDERS["istat"], "constraint_endpoint", "availableconstraint")
@@ -578,10 +585,16 @@ class TestConstraintEndpointPathBuild:
         }
 
     def test_istat_uses_contentconstraint_path(self, tmp_path, monkeypatch):
-        """ISTAT bulk path: first HTTP call goes to /contentconstraint/IT1 (no df_id)."""
+        """ISTAT bulk path: first HTTP call goes to /contentconstraint/IT1 (no df_id).
+
+        With the hub active by default, the SDMX-REST bulk path is bypassed for
+        ISTAT — disable the hub here to keep this test as a regression guard
+        for the bulk-catalog code path.
+        """
         from opensdmx.discovery import get_available_values
 
         monkeypatch.setenv("OPENSDMX_CACHE_DIR", str(tmp_path))
+        monkeypatch.setenv("OPENSDMX_DISABLE_HUB", "1")
         set_provider("istat")
         ds = self._dataset(df_id="22_289_DF_DCIS_POPRES1_24")
 

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -195,7 +195,8 @@ def test_get_available_values_via_hub_iterates_dimensions():
         calls.append(dim_id)
         return {"FREQ": ["A", "M"], "REF_AREA": ["IT", "FR"]}.get(dim_id, [])
 
-    with patch("opensdmx.hub.get_dimension_values_via_hub", side_effect=fake_get_dim):
+    with patch("opensdmx.hub.get_provider", return_value=_HUB_PROVIDER), \
+         patch("opensdmx.hub.get_dimension_values_via_hub", side_effect=fake_get_dim):
         result = get_available_values_via_hub(_dataset(FREQ=1, REF_AREA=2))
 
     assert calls == ["FREQ", "REF_AREA"]
@@ -207,7 +208,8 @@ def test_get_available_values_via_hub_aborts_on_partial_failure():
     def fake_get_dim(df_id, dim_id, version=None, **kwargs):
         return ["A"] if dim_id == "FREQ" else []
 
-    with patch("opensdmx.hub.get_dimension_values_via_hub", side_effect=fake_get_dim):
+    with patch("opensdmx.hub.get_provider", return_value=_HUB_PROVIDER), \
+         patch("opensdmx.hub.get_dimension_values_via_hub", side_effect=fake_get_dim):
         result = get_available_values_via_hub(_dataset(FREQ=1, REF_AREA=2))
 
     assert result == {}
@@ -222,9 +224,22 @@ def test_get_available_values_via_hub_excludes_time_period():
         return ["X"]
 
     ds = _dataset(FREQ=1, TIME_PERIOD=2)
-    with patch("opensdmx.hub.get_dimension_values_via_hub", side_effect=fake_get_dim):
+    with patch("opensdmx.hub.get_provider", return_value=_HUB_PROVIDER), \
+         patch("opensdmx.hub.get_dimension_values_via_hub", side_effect=fake_get_dim):
         get_available_values_via_hub(ds)
     assert "TIME_PERIOD" not in calls
+
+
+def test_get_available_values_via_hub_returns_empty_when_provider_not_configured():
+    """Direct call with a non-hub provider returns {} (graceful contract)."""
+    with patch("opensdmx.hub.get_provider", return_value=_NON_HUB_PROVIDER):
+        assert get_available_values_via_hub(_dataset(FREQ=1, REF_AREA=2)) == {}
+
+
+def test_get_dimension_values_via_hub_returns_empty_when_provider_not_configured():
+    """Direct call with a non-hub provider returns [] (graceful contract)."""
+    with patch("opensdmx.hub.get_provider", return_value=_NON_HUB_PROVIDER):
+        assert get_dimension_values_via_hub("DF_X", "REF_AREA") == []
 
 
 # ── integration with discovery.get_available_values ───────────────────────

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -1,0 +1,295 @@
+"""Tests for opensdmx.hub — `.Stat Suite` hub integration."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from opensdmx.hub import (
+    _dataset_identifier,
+    _hub_node_url,
+    get_available_values_via_hub,
+    get_dimension_values_via_hub,
+    is_hub_enabled,
+)
+
+
+_HUB_PROVIDER = {
+    "name": "ISTAT",
+    "agency_id": "IT1",
+    "language": "it",
+    "hub_base_url": "https://example.test/databrowserhub/api/core",
+    "hub_node_id": "1",
+    "hub_dataset_agency": "IT1",
+    "hub_timeout": 5.0,
+}
+
+_NON_HUB_PROVIDER = {
+    "name": "Eurostat",
+    "agency_id": "ESTAT",
+    "language": "en",
+}
+
+
+def _dataset(df_id="TEST_DF", version="1.0", **dims):
+    if not dims:
+        dims = {"FREQ": 0, "REF_AREA": 1}
+    dimensions = {
+        d: {"id": d, "position": pos, "codelist_id": None}
+        for d, pos in dims.items()
+    }
+    return {
+        "df_id": df_id,
+        "version": version,
+        "df_description": "test",
+        "df_structure_id": "TEST_DSD",
+        "dimensions": dimensions,
+        "filters": {d: "." for d in dimensions},
+    }
+
+
+# ── is_hub_enabled ───────────────────────────────────────────────────────
+
+def test_is_hub_enabled_true_when_configured():
+    assert is_hub_enabled(_HUB_PROVIDER) is True
+
+
+def test_is_hub_enabled_false_for_non_hub_provider():
+    assert is_hub_enabled(_NON_HUB_PROVIDER) is False
+
+
+def test_is_hub_enabled_false_when_disabled_via_env(monkeypatch):
+    monkeypatch.setenv("OPENSDMX_DISABLE_HUB", "1")
+    assert is_hub_enabled(_HUB_PROVIDER) is False
+
+
+def test_is_hub_enabled_reads_active_provider_when_no_arg():
+    """When called without an explicit provider, falls back to base.get_provider()."""
+    with patch("opensdmx.hub.get_provider", return_value=_HUB_PROVIDER):
+        assert is_hub_enabled() is True
+    with patch("opensdmx.hub.get_provider", return_value=_NON_HUB_PROVIDER):
+        assert is_hub_enabled() is False
+
+
+# ── _hub_node_url ─────────────────────────────────────────────────────────
+
+def test_hub_node_url_strips_trailing_slash():
+    p = {**_HUB_PROVIDER, "hub_base_url": "https://example.test/api/core/"}
+    with patch("opensdmx.hub.get_provider", return_value=p):
+        assert _hub_node_url() == "https://example.test/api/core/nodes/1"
+
+
+def test_hub_node_url_uses_node_id():
+    p = {**_HUB_PROVIDER, "hub_node_id": "42"}
+    with patch("opensdmx.hub.get_provider", return_value=p):
+        assert _hub_node_url().endswith("/nodes/42")
+
+
+# ── _dataset_identifier ───────────────────────────────────────────────────
+
+def test_dataset_identifier_with_explicit_agency():
+    with patch("opensdmx.hub.get_provider", return_value=_HUB_PROVIDER):
+        assert _dataset_identifier("DF_X", "1.0") == "IT1,DF_X,1.0"
+
+
+def test_dataset_identifier_falls_back_to_agency_id():
+    p = {k: v for k, v in _HUB_PROVIDER.items() if k != "hub_dataset_agency"}
+    with patch("opensdmx.hub.get_provider", return_value=p):
+        assert _dataset_identifier("DF_X", "1.0") == "IT1,DF_X,1.0"
+
+
+def test_dataset_identifier_default_version():
+    with patch("opensdmx.hub.get_provider", return_value=_HUB_PROVIDER):
+        assert _dataset_identifier("DF_X", None) == "IT1,DF_X,1.0"
+
+
+# ── get_dimension_values_via_hub ──────────────────────────────────────────
+
+_HUB_VALUES_PAYLOAD = {
+    "criteria": [
+        {
+            "id": "REF_AREA",
+            "values": [
+                {"id": "IT", "name": "Italia", "isSelectable": True},
+                {"id": "ITC4", "name": "Lombardia", "isSelectable": True},
+                {"id": "015146", "name": "Milano", "isSelectable": True},
+            ],
+        }
+    ],
+    "obsCount": 12345,
+}
+
+
+def _mock_client_with_response(status: int = 200, payload: dict | None = None,
+                               raise_exc: Exception | None = None):
+    """Build a context-manager mock for httpx.Client that returns a fixed response."""
+    client = MagicMock()
+
+    if raise_exc is not None:
+        client.get.side_effect = raise_exc
+    else:
+        resp = MagicMock()
+        resp.status_code = status
+        if status >= 400:
+            req = httpx.Request("GET", "http://x")
+            err_resp = httpx.Response(status, request=req)
+            resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+                f"{status}", request=req, response=err_resp
+            )
+        else:
+            resp.raise_for_status.return_value = None
+        resp.json.return_value = payload or {}
+        client.get.return_value = resp
+
+    cm = MagicMock()
+    cm.__enter__ = MagicMock(return_value=client)
+    cm.__exit__ = MagicMock(return_value=False)
+    return cm, client
+
+
+def test_get_dimension_values_via_hub_parses_ids():
+    cm, client = _mock_client_with_response(payload=_HUB_VALUES_PAYLOAD)
+    with patch("opensdmx.hub.get_provider", return_value=_HUB_PROVIDER), \
+         patch("opensdmx.hub.httpx.Client", return_value=cm):
+        result = get_dimension_values_via_hub("DF_X", "REF_AREA")
+
+    assert result == ["IT", "ITC4", "015146"]
+    args, kwargs = client.get.call_args
+    url = args[0]
+    assert "/datasets/IT1,DF_X,1.0/column/REF_AREA/partial/values" in url
+    assert kwargs["headers"]["Accept"] == "application/json"
+    assert kwargs["headers"]["userlang"] == "it"
+
+
+def test_get_dimension_values_via_hub_returns_empty_on_http_error():
+    cm, _ = _mock_client_with_response(status=500)
+    with patch("opensdmx.hub.get_provider", return_value=_HUB_PROVIDER), \
+         patch("opensdmx.hub.httpx.Client", return_value=cm):
+        assert get_dimension_values_via_hub("DF_X", "REF_AREA") == []
+
+
+def test_get_dimension_values_via_hub_returns_empty_on_timeout():
+    cm, _ = _mock_client_with_response(raise_exc=httpx.TimeoutException("slow"))
+    with patch("opensdmx.hub.get_provider", return_value=_HUB_PROVIDER), \
+         patch("opensdmx.hub.httpx.Client", return_value=cm):
+        assert get_dimension_values_via_hub("DF_X", "REF_AREA") == []
+
+
+def test_get_dimension_values_via_hub_returns_empty_on_bad_json_shape():
+    cm, _ = _mock_client_with_response(payload={"unexpected": "shape"})
+    with patch("opensdmx.hub.get_provider", return_value=_HUB_PROVIDER), \
+         patch("opensdmx.hub.httpx.Client", return_value=cm):
+        assert get_dimension_values_via_hub("DF_X", "REF_AREA") == []
+
+
+# ── get_available_values_via_hub ──────────────────────────────────────────
+
+def test_get_available_values_via_hub_iterates_dimensions():
+    """Each dimension is queried via hub; results merged into one dict."""
+    calls = []
+
+    def fake_get_dim(df_id, dim_id, version=None, **kwargs):
+        calls.append(dim_id)
+        return {"FREQ": ["A", "M"], "REF_AREA": ["IT", "FR"]}.get(dim_id, [])
+
+    with patch("opensdmx.hub.get_dimension_values_via_hub", side_effect=fake_get_dim):
+        result = get_available_values_via_hub(_dataset(FREQ=1, REF_AREA=2))
+
+    assert calls == ["FREQ", "REF_AREA"]
+    assert result == {"FREQ": ["A", "M"], "REF_AREA": ["IT", "FR"]}
+
+
+def test_get_available_values_via_hub_aborts_on_partial_failure():
+    """If any dimension returns empty, return {} so caller falls through."""
+    def fake_get_dim(df_id, dim_id, version=None, **kwargs):
+        return ["A"] if dim_id == "FREQ" else []
+
+    with patch("opensdmx.hub.get_dimension_values_via_hub", side_effect=fake_get_dim):
+        result = get_available_values_via_hub(_dataset(FREQ=1, REF_AREA=2))
+
+    assert result == {}
+
+
+def test_get_available_values_via_hub_excludes_time_period():
+    """TIME_PERIOD must not be queried via hub (not a codelist dimension)."""
+    calls = []
+
+    def fake_get_dim(df_id, dim_id, version=None, **kwargs):
+        calls.append(dim_id)
+        return ["X"]
+
+    ds = _dataset(FREQ=1, TIME_PERIOD=2)
+    with patch("opensdmx.hub.get_dimension_values_via_hub", side_effect=fake_get_dim):
+        get_available_values_via_hub(ds)
+    assert "TIME_PERIOD" not in calls
+
+
+# ── integration with discovery.get_available_values ───────────────────────
+
+def test_get_available_values_uses_hub_when_enabled(tmp_path, monkeypatch):
+    """When hub is enabled and returns values, the existing SDMX REST chain is skipped."""
+    # Isolate cache so we don't hit a stale entry from a previous run.
+    monkeypatch.setenv("OPENSDMX_CACHE_DIR", str(tmp_path))
+
+    from opensdmx.discovery import get_available_values
+
+    hub_payload = {"FREQ": ["A"], "REF_AREA": ["IT"]}
+
+    sdmx_request_called = MagicMock()
+
+    with patch("opensdmx.discovery.get_provider", return_value=_HUB_PROVIDER), \
+         patch("opensdmx.db_cache.get_cached_available_constraints", return_value=None), \
+         patch("opensdmx.db_cache.save_available_constraints"), \
+         patch("opensdmx.hub.get_available_values_via_hub", return_value=hub_payload), \
+         patch("opensdmx.discovery.sdmx_request_xml", side_effect=sdmx_request_called):
+        result = get_available_values(_dataset(FREQ=1, REF_AREA=2))
+
+    assert "FREQ" in result and "REF_AREA" in result
+    assert result["REF_AREA"].to_series().to_list() == ["IT"]
+    sdmx_request_called.assert_not_called()
+
+
+def test_get_available_values_falls_through_when_hub_returns_empty():
+    """Hub failure → existing chain runs unchanged."""
+    from opensdmx.discovery import get_available_values
+
+    fake_parsed = {"FREQ": ["A"]}
+
+    with patch("opensdmx.discovery.get_provider", return_value=_HUB_PROVIDER), \
+         patch("opensdmx.db_cache.get_cached_available_constraints", return_value=None), \
+         patch("opensdmx.db_cache.save_available_constraints"), \
+         patch("opensdmx.hub.get_available_values_via_hub", return_value={}), \
+         patch("opensdmx.discovery.sdmx_request_xml", return_value=b"<xml/>"), \
+         patch("opensdmx.discovery._parse_constraint_xml", return_value=fake_parsed):
+        result = get_available_values(_dataset(FREQ=1, REF_AREA=2))
+
+    assert "FREQ" in result
+
+
+def test_get_available_values_skips_hub_for_non_hub_provider():
+    """Non-hub providers (Eurostat etc.) never trigger hub code paths."""
+    from opensdmx.discovery import get_available_values
+
+    fake_parsed = {"FREQ": ["A"], "GEO": ["IT"]}
+    hub_called = MagicMock()
+
+    eurostat_provider = {
+        "name": "Eurostat",
+        "agency_id": "ESTAT",
+        "language": "en",
+        "constraint_endpoint": "contentconstraint",
+        "constraint_params": {"references": "none"},
+    }
+
+    with patch("opensdmx.discovery.get_provider", return_value=eurostat_provider), \
+         patch("opensdmx.db_cache.get_cached_available_constraints", return_value=None), \
+         patch("opensdmx.db_cache.save_available_constraints"), \
+         patch("opensdmx.hub.get_available_values_via_hub", side_effect=hub_called), \
+         patch("opensdmx.discovery.sdmx_request_xml", return_value=b"<xml/>"), \
+         patch("opensdmx.discovery._parse_constraint_xml", return_value=fake_parsed):
+        get_available_values(_dataset(FREQ=1, GEO=2))
+
+    hub_called.assert_not_called()


### PR DESCRIPTION
## Summary

Adds an opt-in `.Stat Suite` databrowser hub fast path for ISTAT (and any future provider that exposes a hub). When enabled, `get_available_values()` resolves per-dimension ground-truth codes via sub-second JSON calls instead of the SDMX REST `availableconstraint` endpoint, which times out on large ISTAT datasets.

- New module `src/opensdmx/hub.py` (opt-in via `portals.json`).
- `discovery.get_available_values()` tries the hub after the SQLite cache and before the existing bulk → `availableconstraint` → `serieskeysonly` chain. Any hub failure falls through transparently.
- Only ISTAT touched in `portals.json`; Eurostat, OECD, ECB, ABS, BIS, IMF, Bundesbank, INSEE, World Bank, Comext, Derzhstat keep the existing path byte-for-byte.
- `OPENSDMX_DISABLE_HUB=1` opts out at runtime.

## Why

`41_270_DF_DCIS_MORTIFERITISTR1_1` (11 dimensions, ~573k observations) was unusable: timeout on `availableconstraint` after 30s, then timeout on `serieskeysonly` after another 30s. With the hub path enabled, all dimension values resolve in ~7s end-to-end. Verified live 2026-05-10.

## Test plan

- [x] 19 new tests in `tests/test_hub.py` cover enable/disable (env + provider), URL/identifier build, JSON parsing, error fallback (HTTP error, timeout, malformed JSON, partial failure), TIME_PERIOD exclusion, and discovery integration on hub + non-hub providers
- [x] 2 existing ISTAT regression tests in `tests/test_http.py` opt out of the hub explicitly to keep guarding the SDMX REST `availableconstraint` and bulk `contentconstraint` codepaths
- [x] Full suite: 184 tests pass (`uv run pytest tests/`)
- [x] Live verification on `41_270_DF_DCIS_MORTIFERITISTR1_1` (ISTAT)

## Docs

- `docs/istat/hub-api.md` — full protocol reference for the `.Stat Suite` hub
- `docs/istat/future-ideas.md` — design notes on further hub integrations
- `skills/sdmx-explorer/SKILL.md`, `references/istat-flow.md`, `references/providers.md` — updated to reflect the hub-backed flow and document the `OPENSDMX_DISABLE_HUB` escape hatch
- `LOG.md` — entry tagged `v0.9.0`

## Release

This is a non-breaking new feature → minor bump → **v0.9.0**. The release commit will only bump `pyproject.toml` + refresh `uv.lock`; the `LOG.md` entry is already labeled `v0.9.0`.