### PR TITLE
fix: bulk download, stderr output, dataset error message

### DIFF
--- a/src/opensdmx/base.py
+++ b/src/opensdmx/base.py
@@ -430,4 +430,4 @@ def sdmx_request_csv(path: str, **params):
         resp = sdmx_request(path, accept="application/xml", format=fmt, _is_data=True, **params)
     else:
         resp = sdmx_request(path, accept="text/csv", _is_data=True, **params)
-    return pl.read_csv(io.BytesIO(resp.content), infer_schema_length=10000, schema_overrides={"TIME_PERIOD": pl.Utf8, "OBS_VALUE": pl.Float64, "OBS_FLAG": pl.Utf8, "OBS_STATUS": pl.Utf8, "CONF_STATUS": pl.Utf8})
+    return pl.read_csv(io.BytesIO(resp.content), infer_schema_length=0, null_values=[], schema_overrides={"TIME_PERIOD": pl.Utf8, "OBS_VALUE": pl.Float64, "OBS_FLAG": pl.Utf8, "OBS_STATUS": pl.Utf8, "CONF_STATUS": pl.Utf8})

--- a/src/opensdmx/cli.py
+++ b/src/opensdmx/cli.py
@@ -1096,7 +1096,8 @@ def get(
                 if n_series > _LARGE_DATASET_THRESHOLD:
                     err_console.print(
                         f"[yellow]Warning:[/yellow] this dataset has ~{n_series:,} series (no filters set).\n"
-                        f"Download may be large. Use [cyan]--last-n N[/cyan] to limit, or [cyan]--yes[/cyan] to proceed."
+                        f"Use [cyan]--last-n N[/cyan] to limit results, or [cyan]--yes[/cyan] to download all "
+                        f"in a single bulk request (no chunking — typically fast)."
                     )
                     raise typer.Exit(1)
             except httpx.HTTPStatusError:
@@ -1127,7 +1128,7 @@ def get(
         else:
             err_console.print(f"[red]Error:[/red] unsupported output format '{suffix}'. Supported: .csv, .parquet, .json")
             raise typer.Exit(1)
-        console.print(f"[green]Saved:[/green] {out}")
+        err_console.print(f"[green]Saved:[/green] {out}")
 
     if query_file is not None:
         import yaml
@@ -1139,7 +1140,7 @@ def get(
         )
         with open(query_file, "w") as fh:
             yaml.dump(query_dict, fh, allow_unicode=True, sort_keys=False, default_flow_style=False)
-        console.print(f"[green]Query saved:[/green] {query_file}")
+        err_console.print(f"[green]Query saved:[/green] {query_file}")
 
 
 @app.command()
@@ -1228,7 +1229,7 @@ def run(
         else:
             err_console.print(f"[red]Error:[/red] unsupported format '{suffix}'. Supported: .csv, .parquet, .json")
             raise typer.Exit(1)
-        console.print(f"[green]Saved:[/green] {out}")
+        err_console.print(f"[green]Saved:[/green] {out}")
 
 
 @app.command(context_settings={"allow_extra_args": True, "ignore_unknown_options": True})

--- a/src/opensdmx/discovery.py
+++ b/src/opensdmx/discovery.py
@@ -302,7 +302,11 @@ def load_dataset(dataflow_identifier: str) -> dict:
             match_row = rows.row(0, named=True)
 
     if match_row is None:
-        raise ValueError(f"Could not find dataset with identifier: {dataflow_identifier}")
+        provider_name = get_provider().get("name", "unknown")
+        raise ValueError(
+            f"Could not find dataset '{dataflow_identifier}' in provider '{provider_name}'.\n"
+            f"Use --provider to specify a different provider (e.g. --provider istat, --provider ecb, --provider oecd)."
+        )
 
     structure_id = match_row["df_structure_id"] or match_row["df_id"]
     dimensions = _get_dimensions(structure_id)


### PR DESCRIPTION
## Summary

- **#32** — `pl.read_csv` with `infer_schema_length=10000` inferred REF_AREA as `Int64` (municipality codes look numeric), then crashed on `IT` (Italy aggregate). Fixed with `infer_schema_length=0` + `null_values=[]` so all dimension columns default to `Utf8`.
- **#33** — "Could not find dataset" error didn't mention which provider was queried. Now shows the active provider name and suggests `--provider` alternatives.
- **#35** — Large-dataset warning didn't explain that `--yes` triggers a single wildcard REST request. Updated message clarifies this.
- **#34** (partial) — `Saved:` and `Query saved:` messages were going to stdout via `console.print`; moved to `err_console` (stderr). The `Waiting (Xs)...` countdown was already on stderr — confirmed not reproducible on current main.

## Test plan

- [ ] `opensdmx get 22_315_DF_DCIS_POPORESBIL1_24 --provider istat --yes --FREQ A --DATA_TYPE BEG --SEX 9 --start-period 2024 --end-period 2024 --out /tmp/bulk.csv` → completes, ~16k rows, `IT` present in REF_AREA
- [ ] `opensdmx get 22_315_DF_DCIS_POPORESBIL1_24` → error mentions `Eurostat` and suggests `--provider istat`
- [ ] `opensdmx get NAMA_10_GDP --GEO IT --FREQ A` → large-dataset warning mentions "single bulk request"
- [ ] `opensdmx get NAMA_10_GDP --GEO IT --FREQ A --out /tmp/x.csv 2>/dev/null` → stdout clean (no `Saved:`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)