### PR TITLE
feat: add has_constraint column to dataflow catalog

### DIFF
--- a/skills/sdmx-explorer/SKILL.md
+++ b/skills/sdmx-explorer/SKILL.md
@@ -363,10 +363,12 @@ actually exist in this specific dataflow:
 - **Eurostat** — `contentconstraint`.
 - **All others** — `availableconstraint` (or the provider-specific equivalent).
 
-**Tip for ISTAT exploration — `has_constraint` field in search results:**
-`opensdmx search` results include a `has_constraint` column (visible with
-`--output json`). When `true`, a static `contentconstraint` is available for
-that dataflow — useful as a quick sanity check during exploration.
+**Tip for ISTAT exploration — `has_constraint` flag:**
+The ISTAT dataflow catalog embeds a `has_constraint` boolean (populated at catalog
+build time via a bulk `contentconstraint` call). When `true`, a static constraint
+is available for that dataflow and `opensdmx constraints` will be fast; when
+`false`, it falls back to the dynamic `availableconstraint` endpoint.
+You can inspect it with `opensdmx flows --output json | jq '.[] | select(.has_constraint)'`.
 **Caveat**: even when `has_constraint=true`, the constraint may not cover every
 dimension (e.g. `REF_AREA` is absent from some ISTAT contentconstraints). Always
 verify missing dimensions with `opensdmx constraints` or `opensdmx values`.

--- a/skills/sdmx-explorer/SKILL.md
+++ b/skills/sdmx-explorer/SKILL.md
@@ -363,6 +363,14 @@ actually exist in this specific dataflow:
 - **Eurostat** — `contentconstraint`.
 - **All others** — `availableconstraint` (or the provider-specific equivalent).
 
+**Tip for ISTAT exploration — `has_constraint` field in search results:**
+`opensdmx search` results include a `has_constraint` column (visible with
+`--output json`). When `true`, a static `contentconstraint` is available for
+that dataflow — useful as a quick sanity check during exploration.
+**Caveat**: even when `has_constraint=true`, the constraint may not cover every
+dimension (e.g. `REF_AREA` is absent from some ISTAT contentconstraints). Always
+verify missing dimensions with `opensdmx constraints` or `opensdmx values`.
+
 **Missing dimensions** are now rare. They appear only on providers/datasets
 where the discovery endpoint does not list a particular dimension (e.g. some
 Eurostat dataflows). The CLI flags these inline:

--- a/src/opensdmx/discovery.py
+++ b/src/opensdmx/discovery.py
@@ -137,26 +137,28 @@ def all_available() -> pl.DataFrame:
         catalog_ids = {r["df_id"] for r in records}
         try:
             cc_path = _struct_path(f"contentconstraint/{agency_id}")
-            cc_content = sdmx_request_xml(cc_path, _timeout=30)
+            cc_content = sdmx_request_xml(cc_path, _timeout=30, _max_retries=1)
             bulk_succeeded = True
             # Use raw long_ids for catalog matching (avoids _DF_ truncation mismatch)
             long_ids = _extract_bulk_long_ids(cc_content)
+            parsed = _parse_bulk_constraint_xml(cc_content)
             covered_catalog: set[str] = set()
             for long_id in long_ids:
                 catalog_id = _match_catalog_id(long_id, catalog_ids)
                 if catalog_id:
                     has_constraint_map[catalog_id] = True
                     covered_catalog.add(catalog_id)
-            # Also cache constraint values (uses short_ids from existing parser)
-            parsed = _parse_bulk_constraint_xml(cc_content)
-            for short_id, dims in parsed.items():
-                cache_id = _match_catalog_id(short_id, catalog_ids)
-                if cache_id:
-                    try:
-                        from .db_cache import save_available_constraints
-                        save_available_constraints(cache_id, dims)
-                    except Exception as e:
-                        logger.warning("Could not cache constraints for %s: %s", cache_id, e)
+                    # Cache constraint values under the correct catalog key.
+                    # _parse_bulk_constraint_xml uses the short_id (prefix before _DF_)
+                    # as the key, so derive it from the long_id for the lookup.
+                    short_id = long_id.split("_DF_")[0] if "_DF_" in long_id else long_id
+                    dims = parsed.get(short_id, {})
+                    if dims:
+                        try:
+                            from .db_cache import save_available_constraints
+                            save_available_constraints(catalog_id, dims)
+                        except Exception as e:
+                            logger.warning("Could not cache constraints for %s: %s", catalog_id, e)
             try:
                 from .db_cache import save_bulk_constraint_index
                 save_bulk_constraint_index(agency_id, covered_catalog)
@@ -691,32 +693,6 @@ def _parse_bulk_constraint_xml(content: bytes) -> dict[str, dict[str, list[str]]
     return result
 
 
-def _fetch_and_cache_bulk_constraints(agency_id: str) -> set[str]:
-    """Fetch all contentconstraints in bulk for an agency, cache them, and return covered df_ids."""
-    from .db_cache import save_available_constraints, save_bulk_constraint_index
-
-    path = _struct_path(f"contentconstraint/{agency_id}")
-    try:
-        content = sdmx_request_xml(path)
-    except Exception as e:
-        logger.warning("Could not fetch bulk constraints for %s: %s", agency_id, e)
-        save_bulk_constraint_index(agency_id, set())
-        return set()
-
-    parsed = _parse_bulk_constraint_xml(content)
-    for short_df_id, dims in parsed.items():
-        try:
-            save_available_constraints(short_df_id, dims)
-        except Exception as e:
-            logger.warning("Could not cache constraints for %s: %s", short_df_id, e)
-
-    covered = set(parsed.keys())
-    try:
-        save_bulk_constraint_index(agency_id, covered)
-    except Exception as e:
-        logger.warning("Could not save bulk constraint index: %s", e)
-    return covered
-
 
 def get_available_values(dataset: dict) -> dict[str, pl.DataFrame]:
     """Get all available values for all dimensions via constraint endpoint.
@@ -727,13 +703,13 @@ def get_available_values(dataset: dict) -> dict[str, pl.DataFrame]:
          ground truth, typically sub-second per call, sidesteps the SDMX-REST
          `availableconstraint` timeout pattern on large datasets (still bounded
          by `hub_timeout`; on any failure falls through to step 3)
-      3. Bulk contentconstraint catalog when `constraint_bulk_supported`
+      3. dataset["has_constraint"] flag (populated by all_available() bulk probe):
+         False → skip per-dataflow CC_ call, go directly to availableconstraint
       4. Per-dataflow contentconstraint / availableconstraint
       5. `data?detail=serieskeysonly` fallback
 
     Steps 2+ are gated by provider config: providers without `hub_base_url`
-    skip step 2; providers without `constraint_bulk_supported` skip step 3.
-    Hub failures fall through transparently to the existing chain.
+    skip step 2. Hub failures fall through transparently to the existing chain.
     """
     from .db_cache import get_cached_available_constraints, save_available_constraints
 

--- a/src/opensdmx/discovery.py
+++ b/src/opensdmx/discovery.py
@@ -50,7 +50,25 @@ def _load_cached_dataflows() -> pl.DataFrame | None:
     if path.exists():
         age = time.time() - path.stat().st_mtime
         if age < DATAFLOWS_CACHE_TTL:
-            return pl.read_parquet(path)
+            df = pl.read_parquet(path)
+            if "has_constraint" not in df.columns:
+                df = df.with_columns(pl.lit(None).cast(pl.Boolean).alias("has_constraint"))
+            return df
+    return None
+
+
+def _match_catalog_id(long_id: str, catalog_ids: set[str]) -> str | None:
+    """Map a bulk-CC long df_id to its catalog key.
+
+    ISTAT's CC XML uses the full form (e.g. '41_269_DF_DCIS_INCIDENTISTR1_1')
+    but most catalog entries use a short prefix (e.g. '22_289').
+    Try direct match first, then fall back to the prefix before '_DF_'.
+    """
+    if long_id in catalog_ids:
+        return long_id
+    parts = long_id.split("_DF_")
+    if len(parts) > 1 and parts[0] in catalog_ids:
+        return parts[0]
     return None
 
 
@@ -67,7 +85,7 @@ def all_available() -> pl.DataFrame:
     """List all available datasets for the active provider.
 
     Returns a Polars DataFrame with columns:
-        df_id, version, df_description, df_structure_id
+        df_id, version, df_description, df_structure_id, has_constraint
 
     Results are cached per provider for 24h.
     Invalid datasets (marked via guide) are excluded.
@@ -77,11 +95,12 @@ def all_available() -> pl.DataFrame:
         return _filter_invalid(cached)
 
     agency_id = get_agency_id()
-    language = get_provider()["language"]
+    provider = get_provider()
+    language = provider["language"]
 
-    catalog_agency = get_provider().get("catalog_agency", agency_id)
+    catalog_agency = provider.get("catalog_agency", agency_id)
     path = _struct_path(f"dataflow/{catalog_agency}")
-    dataflow_params = get_provider().get("dataflow_params", {})
+    dataflow_params = provider.get("dataflow_params", {})
     content = sdmx_request_xml(path, **dataflow_params)
     root, ns = xml_parse(content)
 
@@ -110,12 +129,53 @@ def all_available() -> pl.DataFrame:
             "df_structure_id": df_structure_id,
         })
 
+    # Bulk contentconstraint probe: populate has_constraint for providers that support it.
+    # One HTTP call at catalog-build time; result is embedded in the cached Parquet.
+    has_constraint_map: dict[str, bool] = {}
+    bulk_succeeded = False
+    if provider.get("constraint_bulk_supported"):
+        catalog_ids = {r["df_id"] for r in records}
+        try:
+            cc_path = _struct_path(f"contentconstraint/{agency_id}")
+            cc_content = sdmx_request_xml(cc_path, _timeout=30)
+            bulk_succeeded = True
+            # Use raw long_ids for catalog matching (avoids _DF_ truncation mismatch)
+            long_ids = _extract_bulk_long_ids(cc_content)
+            covered_catalog: set[str] = set()
+            for long_id in long_ids:
+                catalog_id = _match_catalog_id(long_id, catalog_ids)
+                if catalog_id:
+                    has_constraint_map[catalog_id] = True
+                    covered_catalog.add(catalog_id)
+            # Also cache constraint values (uses short_ids from existing parser)
+            parsed = _parse_bulk_constraint_xml(cc_content)
+            for short_id, dims in parsed.items():
+                cache_id = _match_catalog_id(short_id, catalog_ids)
+                if cache_id:
+                    try:
+                        from .db_cache import save_available_constraints
+                        save_available_constraints(cache_id, dims)
+                    except Exception as e:
+                        logger.warning("Could not cache constraints for %s: %s", cache_id, e)
+            try:
+                from .db_cache import save_bulk_constraint_index
+                save_bulk_constraint_index(agency_id, covered_catalog)
+            except Exception as e:
+                logger.warning("Could not save bulk constraint index: %s", e)
+        except Exception as e:
+            logger.warning("Could not fetch bulk constraints at catalog time: %s", e)
+
+    has_constraint_col = [
+        has_constraint_map.get(r["df_id"], False if bulk_succeeded else None)
+        for r in records
+    ]
+
     df = pl.DataFrame(records, schema={
         "df_id": pl.Utf8,
         "version": pl.Utf8,
         "df_description": pl.Utf8,
         "df_structure_id": pl.Utf8,
-    })
+    }).with_columns(pl.Series("has_constraint", has_constraint_col, dtype=pl.Boolean))
     try:
         df.write_parquet(_dataflow_cache_path())
     except OSError:
@@ -319,6 +379,7 @@ def load_dataset(dataflow_identifier: str) -> dict:
         "df_structure_id": structure_id,
         "dimensions": dimensions,
         "filters": filters,
+        "has_constraint": match_row.get("has_constraint"),
     }
 
 
@@ -565,6 +626,25 @@ def _fallback_availableconstraint(dataset: dict, provider: dict) -> dict[str, pl
     return {dim_id: pl.DataFrame({"id": codes}) for dim_id, codes in result.items()}
 
 
+def _extract_bulk_long_ids(content: bytes) -> set[str]:
+    """Extract raw df_ids from bulk contentconstraint XML without any truncation."""
+    root, ns = xml_parse(content)
+    struct_ns = ns.get("structure", "")
+    cc_tag = f"{{{struct_ns}}}ContentConstraint" if struct_ns else "ContentConstraint"
+    result: set[str] = set()
+    for cc in root.iter(cc_tag):
+        df_ref_path = (
+            f".//{{{struct_ns}}}ConstraintAttachment/{{{struct_ns}}}Dataflow/Ref"
+            if struct_ns else ".//Ref"
+        )
+        df_ref = cc.find(df_ref_path)
+        if df_ref is not None:
+            long_id = df_ref.get("id", "")
+            if long_id:
+                result.add(long_id)
+    return result
+
+
 def _parse_bulk_constraint_xml(content: bytes) -> dict[str, dict[str, list[str]]]:
     """Parse a bulk contentconstraint response into {short_df_id: {dim_id: [values]}}.
 
@@ -682,27 +762,16 @@ def get_available_values(dataset: dict) -> dict[str, pl.DataFrame]:
     constraint_endpoint = provider.get("constraint_endpoint", "availableconstraint")
     constraint_suffix = provider.get("constraint_path_suffix", "")
 
-    # Bulk path: providers that expose a full constraint catalog in one call (e.g. ISTAT).
-    # Avoids per-dataflow 404 roundtrips for the ~99% of dataflows with no contentconstraint.
-    if provider.get("constraint_bulk_supported") and constraint_endpoint == "contentconstraint":
-        from .db_cache import get_df_ids_with_content_constraint
-        agency_id = provider.get("agency_id", "")
-        covered = get_df_ids_with_content_constraint(agency_id)
-        if covered is None:
-            covered = _fetch_and_cache_bulk_constraints(agency_id)
-        if df_id not in covered:
-            try:
-                return _fallback_availableconstraint(dataset, provider)
-            except ConstraintsTimeout:
-                logger.warning(
-                    "availableconstraint timed out for %s — trying serieskeysonly", df_id
-                )
-                return _fallback_serieskeysonly(dataset, provider)
-        # Data was just populated in available_constraints by the bulk fetch
-        cached = get_cached_available_constraints(df_id)
-        if cached is not None:
-            return {dim_id: pl.DataFrame({"id": codes}) for dim_id, codes in cached.items()}
-        # Edge case: covered by index but not in per-df cache — fall through to per-df call
+    # has_constraint=False means the catalog bulk probe confirmed no CC_ for this df_id.
+    # Skip the per-dataflow CC_ call and go straight to the dynamic fallback.
+    if dataset.get("has_constraint") is False:
+        try:
+            return _fallback_availableconstraint(dataset, provider)
+        except ConstraintsTimeout:
+            logger.warning(
+                "availableconstraint timed out for %s — trying serieskeysonly", df_id
+            )
+            return _fallback_serieskeysonly(dataset, provider)
 
     if constraint_endpoint == "contentconstraint":
         path = f"{constraint_endpoint}/{provider['agency_id']}/{df_id}"

--- a/src/opensdmx/portals.json
+++ b/src/opensdmx/portals.json
@@ -9,6 +9,7 @@
     "language": "en",
     "dataflow_params": {"detail": "allstubs", "references": "none"},
     "constraint_endpoint": "contentconstraint",
+    "constraint_bulk_supported": false,
     "datastructure_agency": "ESTAT",
     "data_format_param": "SDMX-CSV",
     "dataflow_page_url": "https://ec.europa.eu/eurostat/databrowser/product/page/{dataflow_id}",

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -25,6 +25,46 @@ from opensdmx.retrieval import get_data
 # Fixtures / helpers
 # ---------------------------------------------------------------------------
 
+_ISTAT_DATAFLOW_XML = b"""<?xml version="1.0"?>
+<message:Structure
+    xmlns:message="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/message"
+    xmlns:structure="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/structure"
+    xmlns:common="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/common">
+  <message:Structures>
+    <structure:Dataflows>
+      <structure:Dataflow id="22_289" agencyID="IT1" version="1.0">
+        <common:Name xml:lang="it">Popolazione residente</common:Name>
+        <structure:Structure><Ref id="DCIS_POPRES1_24"/></structure:Structure>
+      </structure:Dataflow>
+      <structure:Dataflow id="99_999" agencyID="IT1" version="1.0">
+        <common:Name xml:lang="it">No constraint</common:Name>
+        <structure:Structure><Ref id="DSD_99_999"/></structure:Structure>
+      </structure:Dataflow>
+    </structure:Dataflows>
+  </message:Structures>
+</message:Structure>"""
+
+_ISTAT_CC_XML = b"""<?xml version="1.0"?>
+<message:Structure
+    xmlns:message="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/message"
+    xmlns:structure="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/structure"
+    xmlns:common="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/common">
+  <message:Structures>
+    <structure:Constraints>
+      <structure:ContentConstraint id="CC_22_289" agencyID="IT1" version="1.0" isFinal="false" type="Actual">
+        <structure:ConstraintAttachment>
+          <structure:Dataflow>
+            <Ref id="22_289_DF_DCIS_POPRES1_24" version="1.0" agencyID="IT1" package="datastructure" class="Dataflow"/>
+          </structure:Dataflow>
+        </structure:ConstraintAttachment>
+        <structure:CubeRegion include="true">
+          <common:KeyValue id="FREQ"><common:Value>A</common:Value></common:KeyValue>
+        </structure:CubeRegion>
+      </structure:ContentConstraint>
+    </structure:Constraints>
+  </message:Structures>
+</message:Structure>"""
+
 _DATAFLOW_XML = b"""<?xml version="1.0" encoding="UTF-8"?>
 <message:Structure
     xmlns:message="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/message"
@@ -183,6 +223,70 @@ class TestAllAvailable:
             all_available()
 
         assert cache.exists()
+
+    def test_istat_bulk_ok_populates_has_constraint(self, tmp_path):
+        """all_available() with ISTAT: bulk CC call populates has_constraint True/False."""
+        import polars as pl
+        cache = tmp_path / "dataflows.parquet"
+        set_provider("istat")
+        try:
+            with (
+                patch("opensdmx.discovery.sdmx_request_xml",
+                      side_effect=[_ISTAT_DATAFLOW_XML, _ISTAT_CC_XML]),
+                patch("opensdmx.discovery._load_cached_dataflows", return_value=None),
+                patch("opensdmx.discovery._dataflow_cache_path", return_value=cache),
+                patch("opensdmx.discovery._filter_invalid", side_effect=lambda df: df),
+                patch("opensdmx.db_cache.save_available_constraints"),
+                patch("opensdmx.db_cache.save_bulk_constraint_index"),
+            ):
+                df = all_available()
+        finally:
+            set_provider("eurostat")
+
+        assert "has_constraint" in df.columns
+        assert df.filter(pl.col("df_id") == "22_289")["has_constraint"][0] is True
+        assert df.filter(pl.col("df_id") == "99_999")["has_constraint"][0] is False
+
+    def test_istat_bulk_fail_sets_has_constraint_null(self, tmp_path):
+        """all_available() with ISTAT: bulk CC failure leaves has_constraint as null."""
+        import polars as pl
+        cache = tmp_path / "dataflows.parquet"
+        set_provider("istat")
+        try:
+            with (
+                patch("opensdmx.discovery.sdmx_request_xml",
+                      side_effect=[_ISTAT_DATAFLOW_XML, Exception("bulk CC failed")]),
+                patch("opensdmx.discovery._load_cached_dataflows", return_value=None),
+                patch("opensdmx.discovery._dataflow_cache_path", return_value=cache),
+                patch("opensdmx.discovery._filter_invalid", side_effect=lambda df: df),
+            ):
+                df = all_available()
+        finally:
+            set_provider("eurostat")
+
+        assert "has_constraint" in df.columns
+        assert df["has_constraint"].null_count() == len(df)
+
+    def test_load_cached_dataflows_adds_missing_has_constraint(self, tmp_path):
+        """Old Parquet without has_constraint column gets the column added as null."""
+        import polars as pl
+        from opensdmx.discovery import _load_cached_dataflows
+
+        old_df = pl.DataFrame({
+            "df_id": ["OLD_DF"],
+            "version": ["1.0"],
+            "df_description": ["Old dataset"],
+            "df_structure_id": ["DSD_OLD"],
+        })
+        cache_path = tmp_path / "dataflows.parquet"
+        old_df.write_parquet(cache_path)
+
+        with patch("opensdmx.discovery._dataflow_cache_path", return_value=cache_path):
+            result = _load_cached_dataflows()
+
+        assert result is not None
+        assert "has_constraint" in result.columns
+        assert result["has_constraint"][0] is None
 
 
 # ---------------------------------------------------------------------------
@@ -584,12 +688,12 @@ class TestConstraintEndpointPathBuild:
             "filters": {"FREQ": "."},
         }
 
-    def test_istat_uses_contentconstraint_path(self, tmp_path, monkeypatch):
-        """ISTAT bulk path: first HTTP call goes to /contentconstraint/IT1 (no df_id).
+    def test_istat_has_constraint_false_skips_cc(self, tmp_path, monkeypatch):
+        """has_constraint=False: get_available_values skips CC_ and uses availableconstraint.
 
-        With the hub active by default, the SDMX-REST bulk path is bypassed for
-        ISTAT — disable the hub here to keep this test as a regression guard
-        for the bulk-catalog code path.
+        The bulk CC probe now runs in all_available() at catalog-build time.
+        When the catalog marks a df_id as has_constraint=False, get_available_values
+        must not call the per-dataflow contentconstraint endpoint.
         """
         from opensdmx.discovery import get_available_values
 
@@ -597,15 +701,16 @@ class TestConstraintEndpointPathBuild:
         monkeypatch.setenv("OPENSDMX_DISABLE_HUB", "1")
         set_provider("istat")
         ds = self._dataset(df_id="22_289_DF_DCIS_POPRES1_24")
+        ds["has_constraint"] = False  # populated by all_available() bulk probe
 
         empty_xml = b'<?xml version="1.0"?><message:Structure xmlns:message="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/message"/>'
         with _mock_http_client(empty_xml) as mock_client_class:
             get_available_values(ds)
 
-        # First call must be the bulk fetch: /contentconstraint/IT1 (no specific df_id)
-        first_url = mock_client_class.return_value.get.call_args_list[0][0][0]
-        assert "/contentconstraint/IT1" in first_url
-        assert "22_289_DF_DCIS_POPRES1_24" not in first_url
+        called_urls = [call[0][0] for call in mock_client_class.return_value.get.call_args_list]
+        # Must use availableconstraint (dynamic fallback), not per-dataflow contentconstraint
+        assert any("availableconstraint" in url for url in called_urls)
+        assert not any("/contentconstraint/IT1/" in url for url in called_urls)
 
     def test_eurostat_uses_contentconstraint_path(self, tmp_path, monkeypatch):
         """Regression: Eurostat path build unchanged (already on contentconstraint)."""


### PR DESCRIPTION
## Summary

- Adds `has_constraint: bool | null` column to `dataflows.parquet` at catalog-build time via a single bulk `contentconstraint/{agency}` call
- For ISTAT: correctly maps all 73 dataflows with a static CC_ (out of ~5 000); `get_available_values()` skips the per-dataflow CC_ call for the remaining 98.5% and goes straight to `availableconstraint`
- Fixes a pre-existing key-mismatch bug in `_parse_bulk_constraint_xml`: the `_DF_`-truncation produced short_ids that didn't match full-form catalog entries (e.g. `41_269` instead of `41_269_DF_DCIS_INCIDENTISTR1_1`)
- Documents Eurostat bulk CC 405 via `constraint_bulk_supported: false` in `portals.json`

## Motivation

Discovered during a ISTAT support exchange (ticket #00526149): only ~1.5% of ISTAT dataflows have a static `contentconstraint`, and `availableconstraint` on large dataflows (213M records) times out after 60s+. Without caching the probe result, every query on the same df_id repeated the same failing HTTP calls.

## Test plan

- [x] 201 tests pass (`uv run pytest tests/ -v`)
- [x] 3 new unit tests: bulk OK → True/False, bulk fail → null, old Parquet backward compat
- [x] Smoke test on live ISTAT: 73 `has_constraint=True`, 4 810 `False`, `41_269_DF_DCIS_INCIDENTISTR1_1=True`

🤖 Generated with [Claude Code](https://claude.com/claude-code)