### PR TITLE
fix: init SQLite schema per DB path, not via global flag (#42)

### DIFF
--- a/src/opensdmx/db_cache.py
+++ b/src/opensdmx/db_cache.py
@@ -13,18 +13,18 @@ def _get_db_path() -> Path:
     return get_cache_dir() / "cache.db"
 
 
-_DB_INITIALIZED = False
+_INITIALIZED_DBS: set[str] = set()
 
 
 @contextmanager
 def _db_conn():
     """Yield a ready-to-use connection, then commit and close it."""
-    global _DB_INITIALIZED
-    conn = sqlite3.connect(_get_db_path(), timeout=10)
+    db_path = _get_db_path()
+    conn = sqlite3.connect(db_path, timeout=10)
     conn.row_factory = sqlite3.Row
     conn.execute("PRAGMA journal_mode=DELETE")
     try:
-        if not _DB_INITIALIZED:
+        if str(db_path) not in _INITIALIZED_DBS:
             conn.executescript("""
                 CREATE TABLE IF NOT EXISTS structure_dims (
                     structure_id TEXT NOT NULL,
@@ -69,7 +69,7 @@ def _db_conn():
                     PRIMARY KEY (agency_id, df_id)
                 );
             """)
-            _DB_INITIALIZED = True
+            _INITIALIZED_DBS.add(str(db_path))
         yield conn
         conn.commit()
     except Exception:

--- a/src/opensdmx/db_cache.py
+++ b/src/opensdmx/db_cache.py
@@ -20,11 +20,17 @@ _INITIALIZED_DBS: set[str] = set()
 def _db_conn():
     """Yield a ready-to-use connection, then commit and close it."""
     db_path = _get_db_path()
+    db_key = str(db_path.resolve())
+    db_existed = db_path.exists()
     conn = sqlite3.connect(db_path, timeout=10)
     conn.row_factory = sqlite3.Row
     conn.execute("PRAGMA journal_mode=DELETE")
     try:
-        if str(db_path) not in _INITIALIZED_DBS:
+        # Re-create the schema when this DB file is new to us OR the file did
+        # not exist before connecting (e.g. a fresh provider cache, or the user
+        # deleted cache.db during a long-lived process). Keyed on the resolved
+        # absolute path so a relative path + CWD change can't alias two files.
+        if not db_existed or db_key not in _INITIALIZED_DBS:
             conn.executescript("""
                 CREATE TABLE IF NOT EXISTS structure_dims (
                     structure_id TEXT NOT NULL,
@@ -69,7 +75,7 @@ def _db_conn():
                     PRIMARY KEY (agency_id, df_id)
                 );
             """)
-            _INITIALIZED_DBS.add(str(db_path))
+            _INITIALIZED_DBS.add(db_key)
         yield conn
         conn.commit()
     except Exception:

--- a/tests/test_db_cache.py
+++ b/tests/test_db_cache.py
@@ -14,7 +14,29 @@ def _isolated_db(tmp_path, monkeypatch):
     """Redirect db_cache to a temporary SQLite database for every test."""
     db_file = tmp_path / "test_cache.db"
     monkeypatch.setattr(db_cache, "_get_db_path", lambda: db_file)
-    monkeypatch.setattr(db_cache, "_DB_INITIALIZED", False)
+    monkeypatch.setattr(db_cache, "_INITIALIZED_DBS", set())
+
+
+# ── cross-provider schema init (issue #42) ───────────────────────────
+
+def test_schema_init_per_db_path(tmp_path, monkeypatch):
+    """Switching DB path (new provider) must re-create the schema.
+
+    Regression for issue #42: a global init flag skipped schema creation on
+    the second provider, raising 'no such table: invalid_datasets'.
+    """
+    monkeypatch.setattr(db_cache, "_INITIALIZED_DBS", set())
+    db_a = tmp_path / "a" / "cache.db"
+    db_b = tmp_path / "b" / "cache.db"
+    db_a.parent.mkdir()
+    db_b.parent.mkdir()
+
+    monkeypatch.setattr(db_cache, "_get_db_path", lambda: db_a)
+    assert db_cache.get_invalid_dataset_ids() == set()
+
+    # Second provider — a brand new DB file must still have the schema.
+    monkeypatch.setattr(db_cache, "_get_db_path", lambda: db_b)
+    assert db_cache.get_invalid_dataset_ids() == set()
 
 
 # ── structure dims ───────────────────────────────────────────────────

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -567,7 +567,7 @@ class TestAvailableConstraintTimeout:
         from tenacity import wait_none
         monkeypatch.setattr("opensdmx.base.wait_exponential", lambda **kwargs: wait_none())
         # Force db_cache to re-init schema for the per-test tmp cache dir.
-        monkeypatch.setattr("opensdmx.db_cache._DB_INITIALIZED", False)
+        monkeypatch.setattr("opensdmx.db_cache._INITIALIZED_DBS", set())
         # Skip per-provider rate-limit sleep so multi-attempt cases stay fast.
         monkeypatch.setattr("opensdmx.base._rate_limit_check", lambda is_data=False: None)
 
@@ -674,7 +674,7 @@ class TestConstraintEndpointPathBuild:
     def _setup(self, monkeypatch):
         from tenacity import wait_none
         monkeypatch.setattr("opensdmx.base.wait_exponential", lambda **kwargs: wait_none())
-        monkeypatch.setattr("opensdmx.db_cache._DB_INITIALIZED", False)
+        monkeypatch.setattr("opensdmx.db_cache._INITIALIZED_DBS", set())
         monkeypatch.setattr("opensdmx.base._rate_limit_check", lambda is_data=False: None)
 
     @staticmethod


### PR DESCRIPTION
Fixes #42.

## Problem

`set_provider()` switching (e.g. `eurostat` → `oecd`) made the first
`all_available()` on the new provider crash with
`sqlite3.OperationalError: no such table: invalid_datasets`.

Root cause: `_DB_INITIALIZED` was a module-level `bool`. The first
provider created its schema and set the flag to `True`; the next provider
opens a **different** DB file (separate cache dir), but the flag stayed
`True`, so the schema was never created on the new file.

This is a **library** bug (reproduced via `import opensdmx`), not a CLI one.

## Fix

Replace the global bool with `_INITIALIZED_DBS: set[str]` keyed on the DB
path, so every new DB file initializes its own schema. (Option 1 from the
issue.)

## Verification

- New regression test `test_schema_init_per_db_path` reproducing the
  two-provider scenario — proven to fail with the exact issue error on the
  old code, passes with the fix.
- Updated the 3 existing tests that referenced the old flag.
- Full suite: **208 passed**, `ruff` clean.
- End-to-end on the editable-installed library with a fresh cache dir:
  `eurostat` then `oecd` both return cleanly, no `OperationalError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)