### PR TITLE
feat: add `get --labels` to append human-readable label columns

### DIFF
--- a/LOG.md
+++ b/LOG.md
@@ -1,5 +1,13 @@
 # LOG
 
+## 2026-06-13 — v0.11.0
+
+- feat: `opensdmx get --labels` appends a `<dim>_label` column with the human-readable name for each dimension code (resolved from the codelist cache, in the provider's language); codes are preserved, label column mirrors the data column case + `_label`. Inspired by rsdmx's `as.data.frame(labels=TRUE)`
+- feat: the `--labels` choice is serialized to the YAML query file and honored by `opensdmx run`
+- core: new `enrich_with_labels(dataset, data)` helper in `retrieval.py`, exported from the package
+- docs: document `--labels` in README and the `sdmx-explorer` skill (SKILL.md, visualization.md Rule 5, duckdb-setup.md)
+- test: 5 new tests in `test_labels.py` (enrichment, no-codelist, unmapped→null, query-file round-trip)
+
 ## 2026-06-10 — v0.10.4
 
 - fix: SQLite schema is now initialized per DB file path instead of via a single module-level `_DB_INITIALIZED` flag (#42); switching provider (e.g. `eurostat` → `oecd`) no longer crashes with `no such table: invalid_datasets`

--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ opensdmx info UNE_RT_M
 opensdmx constraints UNE_RT_M geo
 opensdmx get UNE_RT_M --freq M --geo IT --sex T --out data.csv
 
+# Add human-readable labels alongside the codes (geo_label, sex_label, ...)
+opensdmx get UNE_RT_M --freq M --geo IT --sex T --labels --out data.csv
+
 # Save a query for later reuse
 opensdmx get TIPSUN20 --sex T --age Y15-74 --start-period 2020 --query-file unemployment.yaml
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "opensdmx"
-version = "0.10.4"
+version = "0.11.0"
 description = "Simple Python interface to any SDMX 2.1 REST API (Eurostat, ISTAT, and more)"
 readme = "README.md"
 authors = [

--- a/skills/sdmx-explorer/SKILL.md
+++ b/skills/sdmx-explorer/SKILL.md
@@ -547,6 +547,24 @@ Once the user has specified their choices, build the query and fetch the data.
 Note: Eurostat dimension flags are lowercase (`--geo`, `--coicop`, `--freq`).
 ISTAT dimension flags are uppercase (`--REF_AREA`, `--DATA_TYPE`, `--FREQ`).
 
+### Human-readable labels (`--labels`)
+
+The data returned by `opensdmx get` contains only **codes** (`geo=IT`, `sex=T`).
+Add `--labels` to append a sibling `<DIM>_label` column with the human-readable name
+for each code, resolved from the codelist in the provider's language:
+
+```bash
+opensdmx get NAMA_10_GDP --geo IT --sex T --labels --last-n 1
+```
+
+This adds `geo_label` ("Italy"), `sex_label` ("Total"), etc. alongside the original
+code columns (codes are preserved, not replaced). The label column name mirrors the
+data column case + `_label` (`geo` → `geo_label`, `ITTER107` → `ITTER107_label`).
+
+**Always prefer `--labels` when showing data to the user or building tables/charts** —
+never present raw codes when readable labels are available. The flag is also persisted
+in the YAML query file (`--query-file`) and honored by `opensdmx run`.
+
 ### Bulk download — large datasets without REF_AREA filter
 
 When the user wants **all territorial units** (all comuni, all regions, all countries)

--- a/skills/sdmx-explorer/references/duckdb-setup.md
+++ b/skills/sdmx-explorer/references/duckdb-setup.md
@@ -34,6 +34,8 @@ winget install DuckDB.cli
 ## Typical usage with SDMX data
 
 All examples assume the data was downloaded with `opensdmx get ... --out data.csv`.
+Add `--labels` to that command to get `<dim>_label` columns (human-readable names)
+alongside the codes — it avoids a manual codelist join in DuckDB.
 
 ### Quick inspection
 

--- a/skills/sdmx-explorer/references/visualization.md
+++ b/skills/sdmx-explorer/references/visualization.md
@@ -183,7 +183,18 @@ Then plot with `--x year` instead of `--x TIME_PERIOD`.
 be expected to know that `EL` is Greece, `ED7` is a master's degree, or `F` is Female.
 Always join the dimension codes with their labels before plotting.
 
-**How to get labels:**
+**Easiest path — fetch with `--labels`:**
+
+```bash
+# adds geo_label, sex_label, ... alongside the code columns, in one step
+opensdmx get <dataflow_id> --geo IT+DE+EL --labels --out /tmp/data.csv
+```
+
+Then plot with `--x geo_label` (or `--color geo_label`) directly — no DuckDB join
+needed. This is the preferred approach; use the manual join below only when the data
+was already downloaded without `--labels`.
+
+**How to get labels manually (when data lacks `_label` columns):**
 
 ```bash
 # Get geo labels from Eurostat constraints
@@ -256,7 +267,7 @@ Common problems and fixes:
 | Title says "OBS_VALUE"    | Default labels used              | Set `--title`, `--ylabel`, `--xlabel` explicitly          |
 | X-axis labels overlap     | Many categories or long strings  | Use `--geom barh` (flips to horizontal); or `--rotate-x 45` to angle them |
 | X-axis labels missing     | plotnine thins discrete tick labels | Use `--x-all` to force all tick labels. Combine with `--rotate-x 45` if labels overlap. Works with `--facet` and `--color` |
-| Codes shown instead of names | Raw SDMX codes (`EL`, `ED7`, `F`) not replaced | Join with labels via `opensdmx --output csv constraints` + DuckDB JOIN (see Rule 5) |
+| Codes shown instead of names | Raw SDMX codes (`EL`, `ED7`, `F`) not replaced | Re-fetch with `opensdmx get ... --labels` and plot `<dim>_label`; or join manually (see Rule 5) |
 
 ### 3. Present to user
 

--- a/src/opensdmx/__init__.py
+++ b/src/opensdmx/__init__.py
@@ -21,7 +21,7 @@ from .discovery import (
     search_dataset,
     set_filters,
 )
-from .retrieval import fetch, get_data, parse_time_period, run_query
+from .retrieval import enrich_with_labels, fetch, get_data, parse_time_period, run_query
 from .embed import build_embeddings, semantic_search
 from .cli import main
 
@@ -42,6 +42,7 @@ __all__ = [
     "get_data",
     "fetch",
     "run_query",
+    "enrich_with_labels",
     "build_embeddings",
     "semantic_search",
     "set_timeout",

--- a/src/opensdmx/cli.py
+++ b/src/opensdmx/cli.py
@@ -1106,6 +1106,7 @@ def get(
     last_n: Optional[int] = typer.Option(None, "--last-n", help="Return only last N observations per series"),
     first_n: Optional[int] = typer.Option(None, "--first-n", help="Return only first N observations per series"),
     yes: bool = typer.Option(False, "--yes", "-y", help="Download all series in a single wildcard bulk request, skipping the confirmation prompt"),
+    labels: bool = typer.Option(False, "--labels", help="Append a '<DIM>_label' column with the human-readable name for each dimension code"),
     provider: Optional[str] = typer.Option(None, "--provider", "-p", help=_PROVIDER_HELP),
     header: Optional[list[str]] = typer.Option(None, "--header", help="Extra HTTP header in 'Name: Value' format (repeatable)"),
 ):
@@ -1161,6 +1162,10 @@ def get(
         with console.status("[dim]Fetching data...[/dim]"):
             df = get_data(ds, start_period=start_period, end_period=end_period,
                           last_n_observations=last_n, first_n_observations=first_n)
+        if labels:
+            from . import enrich_with_labels
+            with console.status("[dim]Adding labels...[/dim]"):
+                df = enrich_with_labels(ds, df)
     except httpx.HTTPStatusError as e:
         err_console.print(f"[red]HTTP {e.response.status_code}:[/red] {e.request.url}")
         if e.response.status_code in (400, 404):
@@ -1191,7 +1196,7 @@ def get(
         query_dict = build_query_dict(
             ds=ds, filters=filters,
             start_period=start_period, end_period=end_period,
-            last_n=last_n, first_n=first_n, provider=provider,
+            last_n=last_n, first_n=first_n, provider=provider, labels=labels,
         )
         with open(query_file, "w") as fh:
             yaml.dump(query_dict, fh, allow_unicode=True, sort_keys=False, default_flow_style=False)
@@ -1264,6 +1269,10 @@ def run(
         with console.status("[dim]Fetching data...[/dim]"):
             df = get_data(ds, start_period=start_period, end_period=end_period,
                           last_n_observations=last_n, first_n_observations=first_n)
+        if q.get("labels"):
+            from . import enrich_with_labels
+            with console.status("[dim]Adding labels...[/dim]"):
+                df = enrich_with_labels(ds, df)
     except httpx.HTTPStatusError as e:
         err_console.print(f"[red]HTTP {e.response.status_code}:[/red] {e.request.url}")
         raise typer.Exit(1)

--- a/src/opensdmx/retrieval.py
+++ b/src/opensdmx/retrieval.py
@@ -113,6 +113,43 @@ def get_data(
     return data
 
 
+def enrich_with_labels(dataset: dict, data: pl.DataFrame) -> pl.DataFrame:
+    """Append human-readable label columns for each dimension in the data.
+
+    For every dimension whose column appears in ``data`` (matched
+    case-insensitively) and that has a codelist, adds a sibling
+    ``<col>_label`` column with the code's name resolved from the codelist
+    cache, in the provider's language. Original code columns are preserved and
+    row order is unchanged. Dimensions without a codelist add no column; codes
+    with no matching label get a null label.
+
+    Args:
+        dataset: dict returned by load_dataset()
+        data: DataFrame returned by get_data()
+
+    Returns:
+        Polars DataFrame with added ``<col>_label`` columns.
+    """
+    from .discovery import get_dimension_values
+
+    if data.is_empty():
+        return data
+
+    col_by_upper = {c.upper(): c for c in data.columns}
+    for dim_id, info in (dataset.get("dimensions") or {}).items():
+        col = col_by_upper.get(dim_id.upper())
+        if col is None or not (info or {}).get("codelist_id"):
+            continue
+        values = get_dimension_values(dataset, dim_id)
+        if values.is_empty():
+            continue
+        mapping = dict(zip(values["id"], values["name"]))
+        data = data.with_columns(
+            pl.col(col).replace_strict(mapping, default=None).alias(f"{col}_label")
+        )
+    return data
+
+
 def run_query(query_file: str) -> pl.DataFrame:
     """Run a query from a YAML file saved with `opensdmx get --query-file`.
 
@@ -149,13 +186,16 @@ def run_query(query_file: str) -> pl.DataFrame:
     if filters:
         ds = set_filters(ds, **filters)
 
-    return get_data(
+    data = get_data(
         ds,
         start_period=q.get("start_period"),
         end_period=q.get("end_period"),
         last_n_observations=q.get("last_n"),
         first_n_observations=q.get("first_n"),
     )
+    if q.get("labels"):
+        data = enrich_with_labels(ds, data)
+    return data
 
 
 def fetch(

--- a/src/opensdmx/utils.py
+++ b/src/opensdmx/utils.py
@@ -89,6 +89,7 @@ def build_query_dict(
     last_n: int | None = None,
     first_n: int | None = None,
     provider: str | None = None,
+    labels: bool = False,
 ) -> dict:
     """Build a plain dict representing a query, ready for YAML serialisation.
 
@@ -124,6 +125,7 @@ def build_query_dict(
         "end_period": end_period,
         "last_n": last_n,
         "first_n": first_n,
+        "labels": labels,
     }
 
 

--- a/tests/test_labels.py
+++ b/tests/test_labels.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import polars as pl
+
+from opensdmx.retrieval import enrich_with_labels
+from opensdmx.utils import build_query_dict
+
+
+def _dataset() -> dict:
+    return {
+        "df_id": "TEST_DF",
+        "version": "1.0",
+        "df_description": "Test",
+        "df_structure_id": "TEST_DSD",
+        "dimensions": {
+            "GEO": {"id": "GEO", "position": 1, "codelist_id": "CL_GEO"},
+            "SEX": {"id": "SEX", "position": 2, "codelist_id": "CL_SEX"},
+        },
+        "filters": {"GEO": ".", "SEX": "."},
+    }
+
+
+def _fake_values(dataset, dim_id):
+    data = {
+        "GEO": [("IT", "Italy"), ("DE", "Germany")],
+        "SEX": [("T", "Total")],
+    }[dim_id.upper()]
+    return pl.DataFrame(
+        {"id": [r[0] for r in data], "name": [r[1] for r in data]},
+        schema={"id": pl.Utf8, "name": pl.Utf8},
+    )
+
+
+def test_enrich_adds_label_columns_preserving_codes_and_order():
+    # lowercase columns mimic Eurostat SDMX-CSV output
+    df = pl.DataFrame({
+        "geo": ["IT", "DE", "IT"],
+        "sex": ["T", "T", "T"],
+        "TIME_PERIOD": ["2020", "2020", "2021"],
+        "OBS_VALUE": [1.0, 2.0, 3.0],
+    })
+    with patch("opensdmx.discovery.get_dimension_values", side_effect=_fake_values):
+        out = enrich_with_labels(_dataset(), df)
+
+    # codes preserved, order preserved
+    assert out["geo"].to_list() == ["IT", "DE", "IT"]
+    # label columns mirror the actual data column case + _label
+    assert "geo_label" in out.columns
+    assert "sex_label" in out.columns
+    assert out["geo_label"].to_list() == ["Italy", "Germany", "Italy"]
+    assert out["sex_label"].to_list() == ["Total", "Total", "Total"]
+
+
+def test_enrich_dimension_without_codelist_adds_no_column():
+    ds = _dataset()
+    ds["dimensions"]["GEO"]["codelist_id"] = None
+    df = pl.DataFrame({"geo": ["IT"], "sex": ["T"], "OBS_VALUE": [1.0]})
+    with patch("opensdmx.discovery.get_dimension_values", side_effect=_fake_values):
+        out = enrich_with_labels(ds, df)
+    assert "geo_label" not in out.columns
+    assert "sex_label" in out.columns
+
+
+def test_enrich_unmapped_code_yields_null_label():
+    df = pl.DataFrame({"geo": ["IT", "ZZ"], "OBS_VALUE": [1.0, 2.0]})
+    ds = _dataset()
+    del ds["dimensions"]["SEX"]
+    with patch("opensdmx.discovery.get_dimension_values", side_effect=_fake_values):
+        out = enrich_with_labels(ds, df)
+    assert out["geo_label"].to_list() == ["Italy", None]
+
+
+def test_build_query_dict_serializes_labels():
+    ds = _dataset()
+    with patch("opensdmx.utils._get_code_label", return_value=""):
+        q = build_query_dict(ds=ds, filters={}, labels=True)
+    assert q["labels"] is True
+
+    with patch("opensdmx.utils._get_code_label", return_value=""):
+        q2 = build_query_dict(ds=ds, filters={})
+    assert q2["labels"] is False
+
+
+def test_run_query_honors_labels(tmp_path):
+    import yaml
+
+    qfile = tmp_path / "q.yaml"
+    qfile.write_text(yaml.dump({
+        "provider": "eurostat",
+        "dataset": "TEST_DF",
+        "filters": {"GEO": {"value": "IT"}},
+        "labels": True,
+    }))
+
+    ds = _dataset()
+    df = pl.DataFrame({"geo": ["IT"], "sex": ["T"], "OBS_VALUE": [1.0]})
+
+    with patch("opensdmx.base.set_provider"), \
+         patch("opensdmx.retrieval.load_dataset", return_value=ds), \
+         patch("opensdmx.retrieval.set_filters", return_value=ds), \
+         patch("opensdmx.retrieval.get_data", return_value=df), \
+         patch("opensdmx.discovery.get_dimension_values", side_effect=_fake_values):
+        from opensdmx.retrieval import run_query
+        out = run_query(str(qfile))
+
+    assert "geo_label" in out.columns
+    assert out["geo_label"].to_list() == ["Italy"]

--- a/uv.lock
+++ b/uv.lock
@@ -992,7 +992,7 @@ wheels = [
 
 [[package]]
 name = "opensdmx"
-version = "0.10.4"
+version = "0.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb" },


### PR DESCRIPTION
## Why

`opensdmx get` returns data with dimension columns containing only **codes** (`geo=IT`, `sex=T`). The label machinery already existed (`get_dimension_values` powers `values`/`constraints`) but was never applied to the data output. Inspired by rsdmx's `as.data.frame(..., labels=TRUE)`.

## What

- New `--labels` flag on `opensdmx get`: appends a sibling `<DIM>_label` column with the human-readable name for each dimension code, resolved from the codelist cache in the provider's language.
- Codes are **preserved**, not replaced. Label column name mirrors the data column case + `_label` (`geo` → `geo_label`, `ITTER107` → `ITTER107_label`) — keeps each code/label pair visually adjacent and deterministic across providers (Eurostat lowercases, ISTAT uppercases).
- Dimension without a codelist → no column; code with no matching label → null (never fails).
- The choice is serialized into the YAML query file (`--query-file`) and honored by `opensdmx run`.
- New `enrich_with_labels(dataset, data)` helper in `retrieval.py`, exported from the package.

## Example

```
$ opensdmx get NAMA_10_GDP --freq A --geo IT --na_item B1GQ --unit CP_MEUR --last-n 1 --labels
DATAFLOW,...,freq,unit,na_item,geo,TIME_PERIOD,OBS_VALUE,...,freq_label,unit_label,na_item_label,geo_label
ESTAT:NAMA_10_GDP(1.0),...,A,CP_MEUR,B1GQ,IT,2025-01-01,2258048.7,...,Annual,"Current prices, million euro",Gross domestic product at market prices,Italy
```

## Docs & skill

- README `get` examples updated.
- `sdmx-explorer` skill: new "Human-readable labels" section in SKILL.md; `visualization.md` Rule 5 now recommends `--labels` over the manual DuckDB join; `duckdb-setup.md` note.

## Verification

- `ruff check src/` ✓
- `pytest` → **213 passed** (5 new in `test_labels.py`: enrichment, no-codelist, unmapped→null, query-file round-trip)
- Real end-to-end labelled fetch + query-file `run` round-trip verified against Eurostat.

Version bumped to **v0.11.0** (minor — additive, non-breaking). Release (tag, GitHub release, PyPI publish) follows on `main` after merge per `docs/release.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)