### PR TITLE
fix: four verified bugs from the v0.14.0 architecture review

### DIFF
--- a/LOG.md
+++ b/LOG.md
@@ -1,5 +1,16 @@
 # LOG
 
+## 2026-07-18 - architecture review + Phase 1 bug fixes
+
+- docs: full architecture review in `docs/evaluation-v0.14.0.md` — data flow, 19 findings ranked by severity, refactoring strategy in 4 phases, plus an explicit "verified correct, do not change" list. Plan in `tasks/todo-architecture-review.md`.
+- fix(cli): `-o csv` emitted corrupt CSV — `_emit` joined fields with `","` and no quoting, so any description containing a comma split into extra columns (`which`, `providers`). Now delegates to Polars `write_csv()`; `str()` semantics preserved.
+- fix(cli): `-o csv` on a nested payload (`info`, `constraints` summary, `siblings`) fell back to JSON silently. Still JSON — there is no faithful flat form — but now says so on stderr. Two deliberate behaviour additions, not restorations: that stderr warning is new (an empty list is exempt — it is empty, not formless), and a present-but-`None` value now renders as an empty cell instead of the literal `None`. stdout is byte-identical to before in every other case.
+- fix(cli): the large-dataset guard raised `typer.Exit(1)` inside a `try` whose `except Exception` caught it (`typer.Exit` subclasses `RuntimeError`), appending a spurious `Error: 1` after a correct warning. Handler now re-raises `typer.Exit`.
+- fix(cli): that warning said "no filters set" unconditionally, even when filters were passed.
+- fix(utils, ai): codelist values are cached under `{codelist_id}:{lang}` but were read with the bare id, so `_get_code_label` and the AI label map returned nothing on every provider — verified against the live cache (zero rows under a bare key). The AI context was listing raw codes with no labels.
+- chore(deps): declared `pandas` (imported at `cli.py:1456,1473`, previously resolved only transitively via plotnine); removed `duckdb`, declared since v0.2.6 and never imported.
+- test: 14 regressions in `tests/test_phase1_regressions.py`. Suite 229 → 243, ruff and mypy strict green, real-CLI smoke on `search` and `get`.
+
 ## 2026-07-17 - v0.14.0
 
 - release: export types to consumers via the `py.typed` marker (PEP 561) and full `mypy --strict` coverage across the package. No runtime or behaviour change.

--- a/docs/evaluation-v0.14.0.md
+++ b/docs/evaluation-v0.14.0.md
@@ -1,0 +1,280 @@
+# Architecture review — v0.14.0
+
+Independent review of the whole package: reverse-engineered data flow, then a search for bad architecture decisions, duplicate logic, performance bottlenecks, scalability risks and maintainability issues.
+
+Baseline at review time: ruff clean, `mypy --strict` green on 14 modules, 229 tests passing in 9.3 s. Every finding below was verified against the running code — several were reproduced empirically, and the ones that turned out to be false alarms are listed explicitly at the end.
+
+---
+
+## Verdict
+
+The codebase is in good structural health. 5.483 lines of source against 3.333 lines of tests, strict typing with no exemptions, CI running lint + types + tests, and a documented design philosophy that is actually followed in the code. This is not a legacy rescue.
+
+What the review found instead is a specific and consistent pattern: **the core library is sound, and the defects cluster at the edges** — the CLI presentation layer, the packaging metadata, and three places where a second implementation of an existing behaviour was written by hand instead of calling the first one. Two of those edge defects are user-visible bugs that ship today.
+
+---
+
+## Clean architecture breakdown
+
+### Layers, as actually built
+
+```
+cli.py (1666)          presentation — Typer commands, rendering, exit codes
+   |
+   +-- __init__.py     public façade — 25 re-exported names
+   |
+   +-- discovery.py (960)   catalog, structure parsing, filters, constraint resolution
+   |   retrieval.py (228)   data fetch, TIME_PERIOD conversion, label enrichment
+   |   categories.py (361)  category tree
+   |   which.py (99)        command routing hints
+   |   embed.py (214)       semantic search
+   |   ai.py (365) + guide.py (396)   optional LLM-guided session
+   |
+   +-- base.py (439)        transport — provider registry, HTTP, rate limit, retry
+   |   hub.py (211)         ISTAT databrowser fast path        <-- BYPASSES base.py
+   |
+   +-- db_cache.py (311)    SQLite cache
+       cache_config.py (25) TTL constants
+       utils.py (152)       XML helpers, SDMX key builder
+```
+
+The layering is clean with **one documented exception and one undocumented one**. The documented exception is that the CLI reaches past the façade into `discovery`/`db_cache`/`categories` for symbols the façade does not export — a gap in the public API rather than an abuse. The undocumented exception is `hub.py`, covered below.
+
+### The cache design is correct and should not be redesigned
+
+Two layers, and the split follows a consistent rule:
+
+- **Parquet** for whatever is read *in full* every time — catalog, category tree, embeddings. Columnar, whole-table scan, TTL by file mtime.
+- **SQLite** for keyed point lookups with independent per-row TTL — dimensions, codelists, constraints, blacklist.
+
+That is the right split for this workload. Measured: catalog read 5,8 ms warm, `get_cached_dims()` 0,75 ms, SQLite connect+PRAGMA+close 0,29 ms. Largest table observed is 40.456 rows / 7,6 MB — three to four orders of magnitude below where SQLite starts to care.
+
+Every hot query already filters on a **prefix of its table's primary key**, so all of them use the autoindex and are O(log n). There is no missing index. Do not add one.
+
+### Where the time actually goes
+
+The dominant cost is network round-trips and rate-limit sleeps; everything local is noise.
+
+| Path | Cost |
+|---|---|
+| Cold `get` on ISTAT (4 serialized calls, `rate_limit=15 s`) | **~60 s of pure sleeping** before the first byte of data |
+| Same path on Eurostat (`rate_limit=0.5 s`) | ~2 s |
+| Warm `search` end to end | 0,50 s — of which 282 ms is interpreter + imports |
+| Cosine similarity, 9.000 × 768 | < 10 ms |
+
+Two conclusions follow. First, the cache layers are doing exactly the job they exist to do, and the measured warm path is dominated by the fixed import floor, not by any cache operation. Second, **brute-force similarity search is the correct choice at this corpus size** — an ANN index would add a dependency, a build step and an invalidation problem to save single-digit milliseconds. The real latency in `semantic_search` is the Ollama round-trip, not the maths.
+
+---
+
+## Critical problem areas
+
+### Tier 1 — user-visible bugs, verified by reproduction
+
+**1. `-o csv` emits corrupt CSV.** `cli.py:90-95`
+
+When `_emit` receives a list of dicts without a Polars frame, it serializes by hand with `",".join(str(...))` — no quoting, no escaping. Any field containing a comma breaks the row.
+
+```
+$ opensdmx -o csv which "plot"
+command,score,description,group                                    <- 4 fields
+plot,5,Visualize a time series as a line, bar, barh, point, ...    <- 8 fields
+```
+
+Affects `providers` and `which`. Polars is already imported in this module; the manual serialization is avoidable in its entirety.
+
+**2. `typer.Exit(1)` swallowed, printing a spurious `Error: 1`.** `cli.py:1182`
+
+The large-dataset guard raises `typer.Exit(1)` inside the `try` opened at line 1156, whose `except Exception` at 1198 catches it — `typer.Exit` inherits from `RuntimeError`. The exit code survives, but the user sees a garbage `Error: 1` line appended to a correct warning. For a CLI whose primary consumer is an LLM reading stdout, that is a false error signal.
+
+An AST scan of all 51 `raise typer.Exit` sites confirms **1182 is the only one** caught by a broad handler. The defect is isolated, not systemic.
+
+**3. Codelist cache is written under one key and read under another.** `utils.py:77`, `ai.py:79`
+
+- Written as `f"{codelist_id}:{lang}"` — `discovery.py:564`, the only writer.
+- Read as bare `codelist_id` — `utils.py:77` and `ai.py:79`.
+
+Verified against the live cache: every stored key carries the suffix, and there are **zero rows without it**. Both lookups therefore return `None` unconditionally, always, on every provider.
+
+Consequence: `ai.py:81` never builds its label map, so the context handed to the AI lists raw codes with no human-readable names — a silent regression in the one feature that most depends on them. No error, no failing test. `discovery.py:543` reads with the correct key, which is why this was never noticed.
+
+Blast radius is narrow — the AI path is behind the optional `[guide]` extra, and `utils._get_code_label` only feeds the `description` field of saved YAML query files — which is why this is rated below the two CLI bugs despite being unconditional. Note the fix is two lines, not one: `get_provider` is not in scope in `utils.py` and needs a lazy import alongside the existing one.
+
+This also explains a stale claim in `docs/cache.md`: the ER diagram declares a foreign key from `codelist_info` to `codelist_values`, and that join can never match (`AGE` vs `AGE:en`).
+
+### Tier 2 — architectural
+
+**4. `hub.py` bypasses the entire transport layer.** `hub.py:92`
+
+`_hub_get_json` builds its own `httpx.Client` instead of going through `base.sdmx_request`. It therefore has **no portalocker rate-limit lock, no timestamp write, no tenacity retry, and no `_extra_headers`** — while duplicating the one thing it did copy, User-Agent resolution. Worse, `hub.py:200-211` falls back to a sequential loop firing N unthrottled GETs.
+
+This project documents ISTAT as banning IPs for 1-2 days on rate-limit violations. This is the single code path that can burst requests at ISTAT with zero throttling.
+
+**The ban-scope question resolves against us.** `portals.json` puts both endpoints on the *same host*: SDMX at `https://esploradati.istat.it/SDMXWS/rest`, hub at `https://esploradati.istat.it/databrowserhub/api/core`. A per-IP block at that host applies to both paths, so the unthrottled hub loop can plausibly trigger the ban that the SDMX limiter exists to prevent.
+
+**But the obvious fix is wrong.** Routing `_hub_get_json` through `base.sdmx_request` would impose ISTAT's 15 s SDMX rate limit on the hub — and that exclusion is *deliberate*: LOG.md records the hub path as "~1 s/dataflow, outside the 15 s SDMX rate limiter", and the daily constraints-archive job is budgeted on that speed. Imposing 15 s/dataflow would make the archive job 15× slower and blow its budget. The blast radius is also wider than it looks: `scripts/constraints_archive.py:48` imports `_hub_get_json` directly, so the CI job depends on this private function's behaviour. Mechanically it may not even fit — `sdmx_request` composes SDMX-REST paths against `base_url`, and the hub uses a different path root.
+
+The correct shape is to **share the transport hygiene without sharing the rate-limit policy**: give the hub tenacity retry, `_extra_headers` and consistent timeout handling, plus its own pacing calibrated to the hub's tolerance — not the SDMX limiter's 15 s. This is the same "separate limiter per endpoint class" idea already tracked in issue #2 for OECD data-vs-metadata. Calibrate the hub interval from measurement, not from reasoning.
+
+**5. `run` reimplements `retrieval.run_query()`, and they have already diverged.** `cli.py:1244-1305` vs `retrieval.py:154-199`
+
+`run_query` is exported in `__all__`. The CLI command does not call it. The two copies differ already:
+
+| | CLI `run` | `retrieval.run_query` |
+|---|---|---|
+| `--provider` override | yes | absent |
+| `OPENSDMX_PROVIDER` fallback | yes | **absent** — silently stays on eurostat |
+| captures `set_filters` warnings | yes | no |
+
+Two implementations of one behaviour, already out of sync, with the library version being the weaker one — that is the version a downstream importer gets.
+
+**6. The same fetch block is written three times, and the third copy is degraded.** `cli.py:1156-1192`, `1282-1299`, `1416-1421`
+
+`load_dataset → set_filters → get_data → enrich_with_labels` appears in `get`, `run` and `plot`. The `plot` copy does **not** capture `set_filters` warnings, so a suspicious filter value is reported by `get` and silently ignored by `plot`. The output-writing block is likewise duplicated between `get` and `run`, where the error strings differ by one word (`unsupported output format` vs `unsupported format`) — evidence of hand-copying.
+
+**7. Packaging metadata is wrong in two directions.** `pyproject.toml`
+
+- **`duckdb` is declared and never imported.** Zero occurrences across `src/`, `tests/`, `scripts/`. Flagged in three previous evaluations and still shipping.
+- **`pandas` is imported directly and never declared.** `cli.py:1456` and `cli.py:1473` import it; only `pandas-stubs` (dev) appears in the manifest. It resolves today purely because `plotnine` depends on it.
+
+These are the same problem seen from two sides, and they must be fixed together: moving `plotnine` to an optional extra without also declaring and moving `pandas` breaks `opensdmx plot` with an `ImportError`.
+
+**8. Health check is inert, and points at the wrong provider.** `cli.py:157-171`, `191`
+
+`_check_api_reachable` returns early if the rate-limit log file exists (`cli.py:159`, importing the private `base._rate_limit_file`). That file is written on every request and never deleted — so after the first successful call to any provider, the guard short-circuits forever. It protects a virgin install and nothing else.
+
+Underneath that, a latent ordering bug: `_startup` calls the probe at line 191, but `_apply_provider` runs *inside* each command, afterwards. Since `base.py` never reads `OPENSDMX_PROVIDER`, `_active_provider` is still the `"eurostat"` default when the probe fires. On a cold cache, `opensdmx search X --provider istat` probes **Eurostat**. Finding 8a masks 8b on any machine that has run the tool once, which is why this has not surfaced.
+
+### Tier 3 — correctness risks that have not fired yet
+
+**9. Two savers can produce a permanent cache miss.** `db_cache.py:133`, `196`, gate at `174-184`
+
+`save_dims` and `save_codelist_values` use bare `INSERT OR REPLACE` with no prior `DELETE`, unlike the correct `save_available_constraints` at `db_cache.py:236`. When an upstream codelist *shrinks*, orphan rows persist with their original `cached_at` — and the freshness gate tests an **arbitrary** row (`ORDER BY code_id`, then `rows[0]`). If a stale orphan sorts first, that codelist reads as expired forever, triggering a refetch and a 15 s ISTAT sleep on every single invocation, undiagnosable short of deleting `cache.db`. Two-line fix, or change the gate to `MIN(cached_at)`.
+
+**10. `_struct_path` applied inconsistently.** `discovery.py:547` vs `363`
+
+Codelist *descriptions* get the provider's `metadata_prefix`; codelist *values* hardcode the path without it. Bundesbank configures `metadata_prefix: "metadata"`, so `values` and `--labels` are expected to 404 there. The inconsistency is certain from the code; the resulting failure was not confirmed against the live endpoint.
+
+**11. Rate-limit lock is held across the whole HTTP call.** `base.py:320`
+
+Correct for the send-to-send semantics it implements, but it means a multi-minute download **blocks every other opensdmx process on that provider for its full duration**, with no feedback — the countdown at `base.py:246-259` only runs after the lock is acquired. On ISTAT there is no data/structure split, so a large `get` stalls any concurrent `search`. The timestamp is already written *before* the request, so narrowing the lock to the timestamp check/write would work.
+
+**12. `get` pays an extra rate-limited round-trip it does not need.** `cli.py:1171`
+
+The size probe is gated on `last_n`/`first_n`/`yes` but not on whether filters are set. A fully-specified single-cell ISTAT query still pays ~15 s for a probe whose answer is already known.
+
+### Tier 4 — maintainability
+
+**13. Dead code: two SQLite tables written and never read.** `db_cache.py:275-311`
+
+`get_df_ids_with_content_constraint` and `is_bulk_constraint_fresh` form a closed loop — the second is called only by the first, and the first is called by nobody. The signal they would serve, `has_constraint`, already travels in the `dataflows.parquet` column, and that is what `discovery.py:862` actually reads. Two tables, three functions, and a `docs/cache.md` entry describing them as load-bearing.
+
+**14. The two largest commands have no tests.** `cli.py:1123` `get` (104 lines), `cli.py:1324` `plot` (241 lines)
+
+`test_cli.py` covers `search`, `constraints`, `tree`, `which` and the helpers, but never invokes `get` or `plot`. The retrieval layer beneath `get` is well covered, so the network path is safe; what is unprotected is the CLI wrapper — output format selection, `--labels`, `--out`, the large-dataset branch. `plot` is the largest untested function in the package and the sole consumer of the plotnine/pandas stack. `embed.py` is public API with no test file at all.
+
+**15. Silent option-dropping in `search --semantic`.** `cli.py:232-265`
+
+The semantic branch returns at line 265; the category filter and all pagination live after it. `--category`, `--page` and `--all` are accepted and ignored with no warning. Notably, `tree --show-dataflows` handles the analogous case correctly by warning explicitly at `cli.py:967-970` — the pattern to copy is already in the file.
+
+**16. Contradictory exit codes for the same situation.** `cli.py:462` vs `299`
+
+`values` with no results exits **1**; `search` with no results exits **0**. An agent using exit codes to decide whether to retry gets opposite signals for the same semantic outcome. (`which`'s exit 2 is documented and intentional — not an inconsistency.)
+
+**17. Duplicated XML parse of the largest document fetched.** `discovery.py:154-155`
+
+`_extract_bulk_long_ids` and `_parse_bulk_constraint_xml` each call `xml_parse()` on the same bulk contentconstraint bytes — two full tree builds plus two full-tree namespace scans. Trivially merged into one pass.
+
+**18. Eager numpy costs 45 ms on every invocation.** `__init__.py:26` → `embed.py:8`
+
+Measured: 282 ms import, 238 ms with numpy stubbed. Paid by `--help`, `get` and `search`, none of which touch numpy. The module already uses lazy imports for `ollama`; applying the same to numpy recovers 16% of import time. The remaining ~240 ms is polars, httpx, rich and typer — genuinely needed.
+
+**19. `docs/architecture.md` is stale.** Module map omits `hub.py`, `categories.py`, `guide.py`, `which.py`, `cache_config.py` — 1.092 lines, roughly 20% of the package, including the distinctive ISTAT hub path. It also contradicts itself on the cache directory: `~/.cache/opensdmx/eurostat/` in one section, `{agency_id}` in another. The code (`base.py:156`) uses the **preset name** for preset providers and `agency_id` only for custom ones, so the second statement is wrong.
+
+---
+
+## Refactoring strategy
+
+Sequenced so that each phase is independently shippable and leaves the suite green.
+
+### Phase 1 — ship the bug fixes (small, high value)
+
+1. `_emit` CSV: build a Polars frame from the list of dicts and call `write_csv()`, deleting the manual serializer (`cli.py:90-95`). Fixes finding 1 and finding 3-of-Tier-1's sibling — `-o csv` silently returning JSON — in the same edit.
+2. Move `raise typer.Exit(1)` outside the `try`, or re-raise it in the handler (`cli.py:1182`).
+3. Pass `f"{codelist_id}:{lang}"` at `utils.py:77` and `ai.py:79`, matching the writer.
+4. Declare `pandas`; remove `duckdb`.
+
+Each is a handful of lines. Together they close every Tier-1 finding.
+
+Finding 4 (hub) is **not** in this phase despite its severity: the fix needs a measured pacing decision and touches a CI-critical script, so it gets its own change rather than riding along with one-liners.
+
+### Phase 2 — delete duplication
+
+6. `run` calls `retrieval.run_query()`; port the three CLI-only behaviours into the library function first, so the façade version becomes the strong one.
+7. Extract the shared fetch pipeline and the output-writing block used by `get`/`run`/`plot` into two private helpers.
+8. Delete `bulk_constraint_index` / `bulk_constraint_fetch` and their three accessors; drop the tables from `docs/cache.md`.
+9. Merge the double XML parse into a single pass, extracting the 42-line block out of `all_available` — which drops that function below 80 lines as a side effect.
+
+### Phase 3 — packaging and correctness hardening
+
+10. Restructure extras: core keeps `httpx`, `lxml`, `polars`, `pyyaml`, `rich`, `tenacity`, `typer`, `platformdirs`, `portalocker`; `[plot]` takes `plotnine` + `pandas` + `pyarrow`; `[semantic]` takes `ollama` + `numpy`; `[guide]` unchanged. Each lazy import gets a friendly "install `opensdmx[plot]`" message — the pattern already exists at `cli.py:1640`.
+11. Lazy `main` / `build_embeddings` / `semantic_search` via module-level `__getattr__` in `__init__.py`; the `[project.scripts]` entry point keeps working through it.
+12. `DELETE` before `INSERT OR REPLACE` in `save_dims` and `save_codelist_values`; or `MIN(cached_at)` in the gate.
+13. `_struct_path` at `discovery.py:547`.
+14. Gate the size probe on "no filters set" (`cli.py:1171`).
+
+### Phase 4 — tests and docs
+
+15. Tests for CLI `get` and `plot`; tests for the non-Ollama parts of `embed.py`.
+16. Align exit codes for "no results"; add a warning for the options `--semantic` drops.
+17. Update `docs/architecture.md` (5 missing modules, cache-dir contradiction) and `docs/cache.md` (false FK, missing columns).
+
+### Deliberately not doing
+
+Narrowing the rate-limit lock (finding 11) is left out. It is a real limitation, but the current behaviour is conservative in exactly the direction that protects against IP bans, and the project's own guidance is that numeric choices here come from empirical measurement rather than reasoning. It deserves its own measured change, not a drive-by.
+
+---
+
+## Verified as correct — do not change
+
+These were examined and found sound. Several look like problems at first glance.
+
+- **`print()` and direct output.** Intentional and documented — the CLI speaks to an LLM orchestrating it.
+- **The parquet/SQLite split.** Motivated, consistent, correct for the workload.
+- **SQLite indexing.** Every hot query is already O(log n) on a PK-prefix autoindex. `journal_mode=DELETE` is right without in-process parallelism.
+- **Brute-force cosine similarity.** Correct at 9k documents; an ANN index would be a regression in complexity for no measurable gain.
+- **Connection-per-call in `_db_conn`.** 0,29 ms against second-scale network calls.
+- **`base.py:268-283` `_is_retryable_exception`.** Never retries 4xx, with a 501 carve-out from 5xx. For IP-ban providers this is the difference between a transient error and a multi-day block.
+- **`base.py:320`** holding the lock across the whole call *for correctness of the cross-process limit* — see finding 11 for the cost, but the reasoning in the comment is right.
+- **`base.py:324-325`** timestamp written at request start, making the interval send-to-send.
+- **`discovery.py:940-957`** `copy.deepcopy` in `set_filters`/`reset_filters` — genuinely immutable dataset dicts.
+- **`discovery.py:243-271`** `search_dataset` AND→OR fallback with coverage-prioritized scoring.
+- **`_parse_extra_filters`** is properly centralized and reused by both `get` and `plot` — a suspected duplication that is not one.
+- **`tree`'s 48 lines of disambiguation messages.** For an LLM-facing CLI this is value, not bloat.
+- **Lazy imports of `ollama`, `plotnine`, `matplotlib`, `pandas`.** Verified absent from the startup trace.
+- **`scripts/constraints_archive.py`.** Genuinely reuses the library and reimplements nothing; its one private-API import is documented with its rationale.
+
+---
+
+## Findings by severity
+
+| # | Location | Finding | Severity |
+|---|---|---|---|
+| 1 | `cli.py:90-95` | `-o csv` emits corrupt CSV (no quoting) | **High** |
+| 2 | `cli.py:1182` | `typer.Exit` swallowed → spurious `Error: 1` | **High** |
+| 3 | `utils.py:77`, `ai.py:79` | Codelist cache read with wrong key — always misses | Medium-high (unconditional, narrow surface) |
+| 4 | `hub.py:92` | Bypasses transport: no retry, no pacing, same host as the rate-limited SDMX endpoint | **High** |
+| 5 | `cli.py:1244-1305` | `run` duplicates `run_query()`, already diverged | Medium-high |
+| 6 | `cli.py:1416-1421` | Third fetch copy in `plot` drops filter warnings | Medium |
+| 7 | `pyproject.toml` | `pandas` undeclared; `duckdb` orphan | Medium-high |
+| 8 | `cli.py:157-191` | Health check inert, and probes the wrong provider | Medium |
+| 9 | `db_cache.py:133,196` | Missing DELETE → possible permanent cache miss | Medium-low |
+| 10 | `discovery.py:547` | `_struct_path` inconsistency breaks Bundesbank | Medium |
+| 11 | `base.py:320` | Lock held across whole download, blocks other processes | Medium |
+| 12 | `cli.py:1171` | Size probe not gated on filters (~15 s wasted on ISTAT) | Medium |
+| 13 | `db_cache.py:275-311` | Two tables written, never read | Medium (dead weight) |
+| 14 | `cli.py:1123,1324` | `get` and `plot` untested; `embed.py` untested | Medium |
+| 15 | `cli.py:232-265` | `--semantic` silently drops three options | Medium |
+| 16 | `cli.py:462` vs `299` | Exit 1 vs 0 for "no results" | Medium |
+| 17 | `discovery.py:154-155` | Largest XML parsed twice | Medium |
+| 18 | `__init__.py:26` | Eager numpy costs 45 ms per invocation | Low-medium |
+| 19 | `docs/architecture.md` | 5 modules missing; cache-dir self-contradiction | Low |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "lxml>=6.0.2",
     "numpy>=2.4.2",
     "ollama>=0.6.1",
+    "pandas>=2.0",
     "platformdirs>=4.9.4",
     "plotnine>=0.15.3",
     "portalocker>=3.0.0",
@@ -34,7 +35,6 @@ dependencies = [
     "rich>=14.3.3",
     "tenacity>=9.1.4",
     "typer>=0.24.1",
-    "duckdb>=1.5.2",
 ]
 
 [project.optional-dependencies]

--- a/src/opensdmx/ai.py
+++ b/src/opensdmx/ai.py
@@ -76,7 +76,10 @@ def guide_session(ds: dict[str, Any], objective: str, failed_context: str = "") 
 
         labels: dict[str, str] = {}
         if codelist_id:
-            cached_vals = get_cached_codelist_values(codelist_id)
+            # Cached under "{codelist_id}:{lang}" — the bare id never matches.
+            cached_vals = get_cached_codelist_values(
+                f"{codelist_id}:{get_provider()['language']}"
+            )
             if cached_vals:
                 labels = {r["id"]: r["name"] for r in cached_vals}
         all_labels[dim_id] = labels

--- a/src/opensdmx/cli.py
+++ b/src/opensdmx/cli.py
@@ -86,15 +86,26 @@ def _emit(data: object, df: pl.DataFrame | None = None) -> None:
     elif _output_mode == "csv":
         if df is not None:
             sys.stdout.write(df.write_csv())
+        elif isinstance(data, list) and data:
+            # Let Polars handle quoting: hand-rolled joining corrupts any field
+            # containing a comma. Values are stringified so a heterogeneous
+            # column can never fail schema inference.
+            import polars as pl
+            keys = list(data[0].keys())
+            rows = [
+                {k: "" if row.get(k) is None else str(row.get(k)) for k in keys}
+                for row in data
+            ]
+            sys.stdout.write(pl.DataFrame(rows).write_csv())
         else:
-            # Fallback: serialise list-of-dicts manually
-            if isinstance(data, list) and data:
-                keys = list(data[0].keys())
-                sys.stdout.write(",".join(keys) + "\n")
-                for row in data:
-                    sys.stdout.write(",".join(str(row.get(k, "")) for k in keys) + "\n")
-            else:
-                sys.stdout.write(json.dumps(data, ensure_ascii=False) + "\n")
+            # Nested or scalar payloads have no faithful flat-CSV form: emit
+            # JSON as before, but say so rather than doing it silently. An
+            # empty list is not formless, just empty — no warning for it.
+            if not isinstance(data, list):
+                err_console.print(
+                    "[yellow]Warning:[/yellow] this command has no CSV form; emitting JSON."
+                )
+            sys.stdout.write(json.dumps(data, ensure_ascii=False) + "\n")
 
 
 def _version_callback(value: bool) -> None:
@@ -1174,8 +1185,9 @@ def get(
                     probe = get_data(ds, last_n_observations=1)
                 n_series = len(probe)
                 if n_series > _LARGE_DATASET_THRESHOLD:
+                    _scope = "with the current filters" if filters else "no filters set"
                     err_console.print(
-                        f"[yellow]Warning:[/yellow] this dataset has ~{n_series:,} series (no filters set).\n"
+                        f"[yellow]Warning:[/yellow] this dataset has ~{n_series:,} series ({_scope}).\n"
                         f"Use [cyan]--last-n N[/cyan] to limit results, or [cyan]--yes[/cyan] to download all "
                         f"in a single bulk request (no chunking — typically fast)."
                     )
@@ -1195,6 +1207,10 @@ def get(
         if e.response.status_code in (400, 404):
             err_console.print("[yellow]Hint:[/yellow] check filter values with: opensdmx constraints <dataset_id>")
         raise typer.Exit(1)
+    except typer.Exit:
+        # typer.Exit subclasses RuntimeError, so the handler below would swallow
+        # a deliberate exit and reprint it as "Error: 1".
+        raise
     except Exception as e:
         err_console.print(f"[red]Error:[/red] {e}")
         raise typer.Exit(1)

--- a/src/opensdmx/utils.py
+++ b/src/opensdmx/utils.py
@@ -73,8 +73,11 @@ def _get_code_label(codelist_id: str | None, code_value: str) -> str:
     # Only single-value codes can be looked up; skip multi-value (AT+BE+...)
     if "+" in code_value:
         return ""
+    from .base import get_provider
     from .db_cache import get_cached_codelist_values
-    cached = get_cached_codelist_values(codelist_id)
+    # Values are cached under "{codelist_id}:{lang}" (see discovery._load_codelist_records);
+    # reading with the bare id never matches.
+    cached = get_cached_codelist_values(f"{codelist_id}:{get_provider()['language']}")
     if not cached:
         return ""
     for entry in cached:

--- a/tests/test_phase1_regressions.py
+++ b/tests/test_phase1_regressions.py
@@ -1,0 +1,197 @@
+"""Regressions for the v0.14.0 architecture review — Phase 1 bug fixes.
+
+See docs/evaluation-v0.14.0.md findings 1, 2, 3.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+from unittest.mock import patch
+
+import polars as pl
+from typer.testing import CliRunner
+
+from opensdmx import cli
+from opensdmx.cli import app
+
+runner = CliRunner()
+
+
+def _parse_csv(text: str) -> list[list[str]]:
+    return list(csv.reader(io.StringIO(text)))
+
+
+# ── Finding 1: -o csv emitted unquoted, corrupt CSV ──────────────────
+
+
+def test_emit_csv_quotes_fields_containing_commas(capsys):
+    """A field with a comma must not split into extra columns."""
+    data = [{"a": "x", "b": "one, two, three", "c": "y"}]
+    with patch.object(cli, "_output_mode", "csv"):
+        cli._emit(data)
+    rows = _parse_csv(capsys.readouterr().out)
+    assert rows[0] == ["a", "b", "c"]
+    assert rows[1] == ["x", "one, two, three", "y"]
+
+
+def test_emit_csv_row_width_matches_header(capsys):
+    data = [
+        {"cmd": "plot", "desc": "line, bar, point"},
+        {"cmd": "get", "desc": "no commas here"},
+    ]
+    with patch.object(cli, "_output_mode", "csv"):
+        cli._emit(data)
+    rows = _parse_csv(capsys.readouterr().out)
+    assert len({len(r) for r in rows}) == 1, "rows disagree with header on width"
+
+
+def test_emit_csv_handles_quotes_and_newlines(capsys):
+    data = [{"a": 'say "hi"', "b": "line1\nline2"}]
+    with patch.object(cli, "_output_mode", "csv"):
+        cli._emit(data)
+    rows = _parse_csv(capsys.readouterr().out)
+    assert rows[1] == ['say "hi"', "line1\nline2"]
+
+
+def test_emit_csv_missing_key_becomes_empty(capsys):
+    """Keys are taken from the first row; absent values render empty."""
+    data = [{"a": "1", "b": "2"}, {"a": "3"}]
+    with patch.object(cli, "_output_mode", "csv"):
+        cli._emit(data)
+    rows = _parse_csv(capsys.readouterr().out)
+    assert rows[2] == ["3", ""]
+
+
+def test_emit_csv_stringifies_non_string_values(capsys):
+    """str() semantics are unchanged from the hand-rolled serializer."""
+    data = [{"cmd": "plot", "score": 5, "ok": True}]
+    with patch.object(cli, "_output_mode", "csv"):
+        cli._emit(data)
+    rows = _parse_csv(capsys.readouterr().out)
+    assert rows[1] == ["plot", "5", "True"]
+
+
+def test_which_csv_output_is_valid(capsys):
+    """End-to-end: `which` descriptions contain commas."""
+    result = runner.invoke(app, ["-o", "csv", "which", "plot"])
+    assert result.exit_code == 0
+    rows = _parse_csv(result.stdout)
+    assert len(rows) > 1
+    assert len({len(r) for r in rows}) == 1
+
+
+def test_emit_csv_nested_payload_warns_and_emits_json(capsys):
+    """Dicts have no flat CSV form: still JSON, but no longer silently."""
+    data = {"df_id": "X", "dimensions": [{"id": "geo"}]}
+    with patch.object(cli, "_output_mode", "csv"):
+        cli._emit(data)
+    captured = capsys.readouterr()
+    assert json.loads(captured.out) == data
+    assert "no CSV form" in captured.err
+
+
+def test_emit_csv_empty_list_does_not_warn(capsys):
+    """An empty result is empty, not formless — stdout unchanged, no warning."""
+    with patch.object(cli, "_output_mode", "csv"):
+        cli._emit([])
+    captured = capsys.readouterr()
+    assert json.loads(captured.out) == []
+    assert captured.err == ""
+
+
+def test_emit_csv_prefers_dataframe_when_given(capsys):
+    """The df argument still wins over the list fallback."""
+    df = pl.DataFrame({"a": ["v, w"]})
+    with patch.object(cli, "_output_mode", "csv"):
+        cli._emit([{"ignored": "yes"}], df=df)
+    rows = _parse_csv(capsys.readouterr().out)
+    assert rows[0] == ["a"]
+    assert rows[1] == ["v, w"]
+
+
+# ── Finding 2: typer.Exit swallowed by `except Exception` ────────────
+
+
+def test_get_large_dataset_guard_does_not_print_spurious_error():
+    """typer.Exit subclasses RuntimeError; the handler must re-raise it."""
+    fake = pl.DataFrame({"TIME_PERIOD": ["2020"], "OBS_VALUE": [1.0]})
+    with (
+        patch.object(cli, "_LARGE_DATASET_THRESHOLD", 0),
+        patch("opensdmx.load_dataset", return_value={"df_id": "X", "dimensions": {}}),
+        patch("opensdmx.set_filters", side_effect=lambda ds, **k: ds),
+        patch("opensdmx.get_data", return_value=fake),
+    ):
+        result = runner.invoke(app, ["get", "X"])
+
+    assert result.exit_code == 1
+    assert "Warning:" in result.output
+    assert "Error: 1" not in result.output
+
+
+def test_get_large_dataset_message_reflects_filter_state():
+    """The warning must not claim 'no filters set' when filters were passed."""
+    fake = pl.DataFrame({"TIME_PERIOD": ["2020"], "OBS_VALUE": [1.0]})
+    with (
+        patch.object(cli, "_LARGE_DATASET_THRESHOLD", 0),
+        patch("opensdmx.load_dataset", return_value={"df_id": "X", "dimensions": {}}),
+        patch("opensdmx.set_filters", side_effect=lambda ds, **k: ds),
+        patch("opensdmx.get_data", return_value=fake),
+    ):
+        result = runner.invoke(app, ["get", "X", "--geo", "IT"])
+
+    assert result.exit_code == 1
+    assert "no filters set" not in result.output
+    assert "with the current filters" in result.output
+
+
+# ── Finding 3: codelist cache read with the wrong key ────────────────
+
+
+def test_get_code_label_reads_lang_suffixed_key():
+    """Values are written as '{id}:{lang}'; the bare id never matches."""
+    from opensdmx.utils import _get_code_label
+
+    rows = [{"id": "IT", "name": "Italy"}]
+    seen: list[str] = []
+
+    def fake_lookup(key: str):
+        seen.append(key)
+        return rows if key == "GEO:en" else None
+
+    with (
+        patch("opensdmx.db_cache.get_cached_codelist_values", side_effect=fake_lookup),
+        patch("opensdmx.base.get_provider", return_value={"language": "en"}),
+    ):
+        assert _get_code_label("GEO", "IT") == "Italy"
+
+    assert seen == ["GEO:en"], f"looked up {seen}, expected the lang-suffixed key"
+
+
+def test_get_code_label_honours_provider_language():
+    from opensdmx.utils import _get_code_label
+
+    seen: list[str] = []
+
+    def fake_lookup(key: str):
+        seen.append(key)
+        return None
+
+    with (
+        patch("opensdmx.db_cache.get_cached_codelist_values", side_effect=fake_lookup),
+        patch("opensdmx.base.get_provider", return_value={"language": "it"}),
+    ):
+        _get_code_label("GEO", "IT")
+
+    assert seen == ["GEO:it"]
+
+
+def test_get_code_label_still_short_circuits():
+    """Guards that must survive the fix: no codelist, multi-value codes."""
+    from opensdmx.utils import _get_code_label
+
+    with patch("opensdmx.db_cache.get_cached_codelist_values") as lookup:
+        assert _get_code_label(None, "IT") == ""
+        assert _get_code_label("GEO", "IT+FR") == ""
+        lookup.assert_not_called()

--- a/tests/test_phase1_regressions.py
+++ b/tests/test_phase1_regressions.py
@@ -73,9 +73,10 @@ def test_emit_csv_stringifies_non_string_values(capsys):
     assert rows[1] == ["plot", "5", "True"]
 
 
-def test_which_csv_output_is_valid(capsys):
+def test_which_csv_output_is_valid():
     """End-to-end: `which` descriptions contain commas."""
-    result = runner.invoke(app, ["-o", "csv", "which", "plot"])
+    with patch("opensdmx.cli._check_api_reachable"):
+        result = runner.invoke(app, ["-o", "csv", "which", "plot"])
     assert result.exit_code == 0
     rows = _parse_csv(result.stdout)
     assert len(rows) > 1
@@ -119,6 +120,7 @@ def test_get_large_dataset_guard_does_not_print_spurious_error():
     fake = pl.DataFrame({"TIME_PERIOD": ["2020"], "OBS_VALUE": [1.0]})
     with (
         patch.object(cli, "_LARGE_DATASET_THRESHOLD", 0),
+        patch("opensdmx.cli._check_api_reachable"),
         patch("opensdmx.load_dataset", return_value={"df_id": "X", "dimensions": {}}),
         patch("opensdmx.set_filters", side_effect=lambda ds, **k: ds),
         patch("opensdmx.get_data", return_value=fake),
@@ -126,7 +128,9 @@ def test_get_large_dataset_guard_does_not_print_spurious_error():
         result = runner.invoke(app, ["get", "X"])
 
     assert result.exit_code == 1
-    assert "Warning:" in result.output
+    # The warning belongs on stderr, so assert it there specifically.
+    assert "Warning:" in result.stderr
+    # The spurious line must appear on neither stream: result.output is combined.
     assert "Error: 1" not in result.output
 
 
@@ -135,6 +139,7 @@ def test_get_large_dataset_message_reflects_filter_state():
     fake = pl.DataFrame({"TIME_PERIOD": ["2020"], "OBS_VALUE": [1.0]})
     with (
         patch.object(cli, "_LARGE_DATASET_THRESHOLD", 0),
+        patch("opensdmx.cli._check_api_reachable"),
         patch("opensdmx.load_dataset", return_value={"df_id": "X", "dimensions": {}}),
         patch("opensdmx.set_filters", side_effect=lambda ds, **k: ds),
         patch("opensdmx.get_data", return_value=fake),
@@ -142,8 +147,8 @@ def test_get_large_dataset_message_reflects_filter_state():
         result = runner.invoke(app, ["get", "X", "--geo", "IT"])
 
     assert result.exit_code == 1
-    assert "no filters set" not in result.output
-    assert "with the current filters" in result.output
+    assert "no filters set" not in result.stderr
+    assert "with the current filters" in result.stderr
 
 
 # ── Finding 3: codelist cache read with the wrong key ────────────────

--- a/uv.lock
+++ b/uv.lock
@@ -392,35 +392,6 @@ wheels = [
 ]
 
 [[package]]
-name = "duckdb"
-version = "1.5.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0c/66/744b4931b799a42f8cb9bc7a6f169e7b8e51195b62b246db407fd90bf15f/duckdb-1.5.2.tar.gz", hash = "sha256:638da0d5102b6cb6f7d47f83d0600708ac1d3cb46c5e9aaabc845f9ba4d69246", size = 18017166, upload-time = "2026-04-13T11:30:09.065Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/41/de/ebe66bbe78125fc610f4fd415447a65349d94245950f3b3dfb31d028af02/duckdb-1.5.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:e6495b00cad16888384119842797c49316a96ae1cb132bb03856d980d95afee1", size = 30064950, upload-time = "2026-04-13T11:29:11.468Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/8a/3e25b5d03bcf1fb99d189912f8ce92b1db4f9c8778e1b1f55745973a855a/duckdb-1.5.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d72b8856b1839d35648f38301b058f6232f4d36b463fe4dc8f4d3fdff2df1a2e", size = 15969113, upload-time = "2026-04-13T11:29:14.139Z" },
-    { url = "https://files.pythonhosted.org/packages/19/bb/58001f0815002b1a93431bf907f77854085c7d049b83d521814a07b9db0b/duckdb-1.5.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2a1de4f4d454b8c97aec546c82003fc834d3422ce4bc6a19902f3462ef293bed", size = 14224774, upload-time = "2026-04-13T11:29:16.758Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/2f/a7f0de9509d1cef35608aeb382919041cdd70f58c173865c3da6a0d87979/duckdb-1.5.2-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ce0b8141a10d37ecef729c45bc41d334854013f4389f1488bd6035c5579aaac1", size = 19313510, upload-time = "2026-04-13T11:29:19.574Z" },
-    { url = "https://files.pythonhosted.org/packages/26/78/eb1e064ea8b9df3b87b167bfd7a407b2f615a4291e06cba756727adfa06c/duckdb-1.5.2-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c99ef73a277c8921bc0a1f16dee38d924484251d9cfd20951748c20fcd5ed855", size = 21429692, upload-time = "2026-04-13T11:29:22.575Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/12/05b0c47d14839925c5e35b79081d918ca82e3f236bb724a6f58409dd5291/duckdb-1.5.2-cp312-cp312-win_amd64.whl", hash = "sha256:8d599758b4e48bf12e18c9b960cf491d219f0c4972d19a45489c05cc5ab36f83", size = 13107594, upload-time = "2026-04-13T11:29:25.43Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/2c/80558a82b236e044330e84a154b96aacddb343316b479f3d49be03ea11cb/duckdb-1.5.2-cp312-cp312-win_arm64.whl", hash = "sha256:fc85a5dbcbe6eccac1113c72370d1d3aacfdd49198d63950bdf7d8638a307f00", size = 13927537, upload-time = "2026-04-13T11:29:27.842Z" },
-    { url = "https://files.pythonhosted.org/packages/98/f2/e3d742808f138d374be4bb516fade3d1f33749b813650810ab7885cdc363/duckdb-1.5.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:4420b3f47027a7849d0e1815532007f377fa95ee5810b47ea717d35525c12f79", size = 30064879, upload-time = "2026-04-13T11:29:30.763Z" },
-    { url = "https://files.pythonhosted.org/packages/72/0d/f3dc1cf97e1267ca15e4307d456f96ce583961f0703fd75e62b2ad8d64fa/duckdb-1.5.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:bb42e6ed543902e14eae647850da24103a89f0bc2587dec5601b1c1f213bd2ed", size = 15969327, upload-time = "2026-04-13T11:29:33.481Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/e0/d5418def53ae4e05a63075705ff44ed5af5a1a5932627eb2b600c5df1c93/duckdb-1.5.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:98c0535cd6d901f61a5ea3c2e26a1fd28482953d794deb183daf568e3aa5dda6", size = 14225107, upload-time = "2026-04-13T11:29:35.882Z" },
-    { url = "https://files.pythonhosted.org/packages/16/a7/15aaa59dbecc35e9711980fcdbf525b32a52470b32d18ef678193a146213/duckdb-1.5.2-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:486c862bf7f163c0110b6d85b3e5c031d224a671cca468f12ebb1d3a348f6b39", size = 19313433, upload-time = "2026-04-13T11:29:38.367Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/21/d903cc63a5140c822b7b62b373a87dc557e60c29b321dfb435061c5e67cf/duckdb-1.5.2-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:70631c847ca918ee710ec874241b00cf9d2e5be90762cbb2a0389f17823c08f7", size = 21429837, upload-time = "2026-04-13T11:29:41.135Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/0a/b770d1f60c70597302130d6247f418549b7094251a02348fbaf1c7e147ae/duckdb-1.5.2-cp313-cp313-win_amd64.whl", hash = "sha256:52a21823f3fbb52f0f0e5425e20b07391ad882464b955879499b5ff0b45a376b", size = 13107699, upload-time = "2026-04-13T11:29:43.905Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/cf/e200fe431d700962d1a908d2ce89f53ccee1cc8db260174ae663ba09686b/duckdb-1.5.2-cp313-cp313-win_arm64.whl", hash = "sha256:411ad438bd4140f189a10e7f515781335962c5d18bd07837dc6d202e3985253d", size = 13927646, upload-time = "2026-04-13T11:29:46.598Z" },
-    { url = "https://files.pythonhosted.org/packages/83/a1/f6286c67726cc1ea60a6e3c0d9fbc66527dde24ae089a51bbe298b13ca78/duckdb-1.5.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:6b0fe75c148000f060aa1a27b293cacc0ea08cc1cad724fbf2143d56070a3785", size = 30078598, upload-time = "2026-04-13T11:29:49.828Z" },
-    { url = "https://files.pythonhosted.org/packages/de/6a/59febb02f21a4a5c6b0b0099ef7c965fdd5e61e4904cf813809bb792e35f/duckdb-1.5.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:35579b8e3a064b5eaf15b0eafc558056a13f79a0a62e34cc4baf57119daecfec", size = 15975120, upload-time = "2026-04-13T11:29:52.631Z" },
-    { url = "https://files.pythonhosted.org/packages/09/70/ce750854d37bb5a45cccbb2c3cb04df4af56aea8fc30a2499bb643b4a9c0/duckdb-1.5.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ea58ff5b0880593a280cf5511734b17711b32ee1f58b47d726e8600848358160", size = 14227762, upload-time = "2026-04-13T11:29:55.564Z" },
-    { url = "https://files.pythonhosted.org/packages/28/dc/ad45ac3c0b6c4687dc649e8f6cf01af1c8b0443932a39b2abb4ebcb3babd/duckdb-1.5.2-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ef461bca07313412dc09961c4a4757a851f56b95ac01c58fac6007632b7b94f2", size = 19315668, upload-time = "2026-04-13T11:29:58.427Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/b1/1464f468d2e5813f5808de95df9d3113a645a5bfa2ffcaecbc542ddae272/duckdb-1.5.2-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:be37680ddb380015cb37318e378c53511c45c4f0d8fac5599d22b7d092b9217a", size = 21434056, upload-time = "2026-04-13T11:30:01.238Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/32/6673607e024722473fa7aafdd29c0e3dd231dd528f6cd8b5797fbeeb229d/duckdb-1.5.2-cp314-cp314-win_amd64.whl", hash = "sha256:0b291786014df1133f8f18b9df4d004484613146e858d71a21791e0fcca16cf4", size = 13633667, upload-time = "2026-04-13T11:30:04.05Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/e3/9d34173ec068631faea3ea6e73050700729363e7e33306a9a3218e5cdc61/duckdb-1.5.2-cp314-cp314-win_arm64.whl", hash = "sha256:c9f3e0b71b8a50fccfb42794899285d9d318ce2503782b9dd54868e5ecd0ad31", size = 14402513, upload-time = "2026-04-13T11:30:06.609Z" },
-]
-
-[[package]]
 name = "fonttools"
 version = "4.61.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1169,11 +1140,11 @@ name = "opensdmx"
 version = "0.14.0"
 source = { editable = "." }
 dependencies = [
-    { name = "duckdb" },
     { name = "httpx", extra = ["socks"] },
     { name = "lxml" },
     { name = "numpy" },
     { name = "ollama" },
+    { name = "pandas" },
     { name = "platformdirs" },
     { name = "plotnine" },
     { name = "polars" },
@@ -1205,11 +1176,11 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "chatlas", extras = ["google"], marker = "extra == 'guide'", specifier = ">=0.7" },
-    { name = "duckdb", specifier = ">=1.5.2" },
     { name = "httpx", extras = ["socks"], specifier = ">=0.28.1" },
     { name = "lxml", specifier = ">=6.0.2" },
     { name = "numpy", specifier = ">=2.4.2" },
     { name = "ollama", specifier = ">=0.6.1" },
+    { name = "pandas", specifier = ">=2.0" },
     { name = "platformdirs", specifier = ">=4.9.4" },
     { name = "plotnine", specifier = ">=0.15.3" },
     { name = "polars", specifier = ">=1.38.1" },


### PR DESCRIPTION
Phase 1 of the architecture review in `docs/evaluation-v0.14.0.md`. Four bugs that ship today, each reproduced before and after. No refactoring here — that is Phase 2.

## The bugs

**1. `-o csv` emitted corrupt CSV** — `cli.py:90`

`_emit` joined fields with `","` and no quoting. Both commands that hit this path ship descriptions containing commas:

```
$ opensdmx -o csv which "plot"
command,score,description,group                                  <- 4 fields
plot,5,Visualize a time series as a line, bar, point...,Data...  <- 8 fields
```

Now delegates to Polars `write_csv()`. Verified with a real `csv.reader`: uniform width on `which` and `providers`.

**2. Spurious `Error: 1` after a correct warning** — `cli.py:1182`

The large-dataset guard raised `typer.Exit(1)` inside a `try` whose `except Exception` caught it — `typer.Exit` subclasses `RuntimeError` (MRO verified on the installed Typer 0.24.1). The exit code survived, but a garbage `Error: 1` line was appended. For a CLI whose output is parsed by an LLM orchestrator, that is a false error signal.

An AST scan of all 51 `raise typer.Exit` sites confirmed this was the only one caught by a broad handler.

**3. Codelist cache written under one key, read under another** — `utils.py:77`, `ai.py:79`

- Written as `f"{codelist_id}:{lang}"` (`discovery.py:564`, the only writer)
- Read as bare `codelist_id`

Verified against the live cache: **zero rows** exist under a bare key, so both lookups returned `None` unconditionally, on every provider. `ai.py:81` therefore never built its label map — the context handed to the AI listed raw codes with no human-readable names. No error, no failing test.

```
GEO      -> None
GEO:en   -> 4292 rows
_get_code_label("GEO", "IT")  ->  'Italy'   (was '')
```

**4. Dependency metadata wrong in both directions** — `pyproject.toml`

- `pandas` imported at `cli.py:1456,1473`, never declared — resolved only transitively via plotnine
- `duckdb` declared since v0.2.6, never imported anywhere

## Behaviour changes, named explicitly

Two changes are additions rather than restorations:

- the stderr warning when `-o csv` gets a nested payload is new (an empty list is exempt — empty is not formless)
- a present-but-`None` value now renders as an empty cell instead of the literal `None`

stdout is byte-identical to before in every other case. The `(no filters set)` → `(with the current filters)` message is a straight fix: it was factually false.

## Verification

- 229 → **243 tests**, 14 new regressions in `tests/test_phase1_regressions.py`
- `ruff check src/` clean, `mypy --strict` green on 14 modules
- Real-CLI smoke against Eurostat: `search`, and `get` writing a CSV

## Not in this PR

The highest-severity finding — `hub.py` bypassing the transport layer with no retry and no pacing, on the **same host** as the rate-limited SDMX endpoint — is deliberately excluded. The obvious fix (routing through `base.sdmx_request`) would impose ISTAT's 15 s limit on a path deliberately excluded from it, making the daily archive job 15× slower. It needs a measured pacing decision and touches `scripts/constraints_archive.py`, so it gets its own PR.

Also noted while working: `tests/` is not linted — CI runs `ruff check src/` only, and `test_base.py` / `test_db_cache.py` carry 6 unused-import errors. Left out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)