### PR TITLE
refactor: remove duplication (Phase 2 of the architecture review)

### DIFF
--- a/LOG.md
+++ b/LOG.md
@@ -1,5 +1,15 @@
 # LOG
 
+## 2026-07-18 - Phase 2: remove duplication
+
+- refactor(retrieval, cli): `opensdmx run` reimplemented `retrieval.run_query()` — public API, exported in `__all__` — and the copies had diverged. The CLI honoured `OPENSDMX_PROVIDER` and accepted `--provider`; the library did neither, so the same YAML file behaved differently depending on the caller. `run_query()` gains a `provider` argument and the env fallback; the CLI now calls it. **Behaviour change for library users**: a query file with no `provider` field now respects `OPENSDMX_PROVIDER` instead of silently staying on the default.
+- feat(base): `set_provider_from_env()` — resolves `OPENSDMX_PROVIDER` including aliases, so library entry points and the CLI agree. `set_provider()` alone never resolved aliases.
+- refactor(cli): extracted `_load_and_filter()` and `_fetch_frame()`. The `load_dataset → set_filters → get_data → enrich_with_labels` pipeline was written three times, and the `plot` copy had already degraded — it did not capture `set_filters` warnings, so a suspicious filter value was reported by `get` and silently ignored by `plot`. Verified: `plot` now surfaces it.
+- refactor(cli): extracted `_write_output()`, duplicated between `get` and `run` down to a one-word difference in the error string (`unsupported output format` vs `unsupported format`). `run` now uses the former wording.
+- perf(discovery): `parse_bulk_constraints()` builds the tree once. `_extract_bulk_long_ids` and `_parse_bulk_constraint_xml` each called `xml_parse()` on the same bulk contentconstraint bytes — the largest XML the library fetches — for two full tree builds and two namespace scans.
+- chore(db_cache): deleted `bulk_constraint_fetch` and `bulk_constraint_index`. Written on every catalog rebuild, never read: their only reader had no callers. The signal travels in the `has_constraint` column of `dataflows.parquet`.
+- test: 15 regressions in `tests/test_phase2_dedup.py`. Suite 243 → 258, ruff and mypy strict green, real-CLI smoke on `get --query-file`, `run` and `plot`.
+
 ## 2026-07-18 - v0.14.1
 
 - release: patch shipping the four Phase 1 bug fixes below. Most user-visible is `-o csv`, which emitted corrupt CSV whenever a field contained a comma — `which` and `providers` both do. No API change.

--- a/src/opensdmx/base.py
+++ b/src/opensdmx/base.py
@@ -97,22 +97,44 @@ def set_provider(
         }
 
 
+def resolve_provider(name: str, agency_id: str | None = None) -> None:
+    """Set the active provider from a preset name, an alias, or a base URL.
+
+    Single resolution path shared by the CLI and by library entry points, so a
+    name is accepted, rejected and alias-expanded identically everywhere.
+
+    Args:
+        name:      preset key, alias (see PROVIDER_ALIASES), or base URL
+        agency_id: agency for a custom URL; falls back to OPENSDMX_AGENCY
+
+    Raises:
+        ValueError: if `name` is neither a known preset/alias nor a URL.
+    """
+    import os
+
+    resolved = PROVIDER_ALIASES.get(name, name)
+    if resolved not in PROVIDERS and not resolved.startswith("http"):
+        valid = ", ".join(sorted(PROVIDERS))
+        raise ValueError(f"unknown provider '{name}'. Valid: {valid}")
+    set_provider(resolved, agency_id=agency_id or os.environ.get("OPENSDMX_AGENCY"))
+
+
 def set_provider_from_env() -> bool:
     """Set the active provider from OPENSDMX_PROVIDER, resolving aliases.
 
     Returns True if the variable was set and applied, False otherwise. Kept
     here rather than in the CLI so library entry points resolve the provider
     the same way `opensdmx` does.
+
+    Raises:
+        ValueError: if OPENSDMX_PROVIDER holds an unknown non-URL value.
     """
     import os
 
     name = os.environ.get("OPENSDMX_PROVIDER")
     if not name:
         return False
-    set_provider(
-        PROVIDER_ALIASES.get(name, name),
-        agency_id=os.environ.get("OPENSDMX_AGENCY"),
-    )
+    resolve_provider(name)
     return True
 
 

--- a/src/opensdmx/base.py
+++ b/src/opensdmx/base.py
@@ -97,6 +97,25 @@ def set_provider(
         }
 
 
+def set_provider_from_env() -> bool:
+    """Set the active provider from OPENSDMX_PROVIDER, resolving aliases.
+
+    Returns True if the variable was set and applied, False otherwise. Kept
+    here rather than in the CLI so library entry points resolve the provider
+    the same way `opensdmx` does.
+    """
+    import os
+
+    name = os.environ.get("OPENSDMX_PROVIDER")
+    if not name:
+        return False
+    set_provider(
+        PROVIDER_ALIASES.get(name, name),
+        agency_id=os.environ.get("OPENSDMX_AGENCY"),
+    )
+    return True
+
+
 def get_provider() -> dict[str, Any]:
     """Return the active provider configuration dict."""
     if isinstance(_active_provider, dict):

--- a/src/opensdmx/cli.py
+++ b/src/opensdmx/cli.py
@@ -208,16 +208,17 @@ def _parse_extra_filters(ctx: typer.Context) -> dict[str, Any]:
 def _apply_provider(provider: str | None) -> None:
     """Set active provider from CLI option or OPENSDMX_PROVIDER env var."""
     import os
-    resolved = provider or os.environ.get("OPENSDMX_PROVIDER")
-    if resolved:
-        from .base import PROVIDER_ALIASES, PROVIDERS, set_provider
-        resolved = PROVIDER_ALIASES.get(resolved, resolved)
-        if resolved not in PROVIDERS and not resolved.startswith("http"):
-            valid = ", ".join(sorted(PROVIDERS))
-            err_console.print(f"[red]Error:[/red] unknown provider '{resolved}'. Valid: {valid}")
-            raise typer.Exit(1)
-        agency_id = os.environ.get("OPENSDMX_AGENCY")
-        set_provider(resolved, agency_id=agency_id)
+
+    from .base import resolve_provider
+
+    name = provider or os.environ.get("OPENSDMX_PROVIDER")
+    if not name:
+        return
+    try:
+        resolve_provider(name)
+    except ValueError as e:
+        err_console.print(f"[red]Error:[/red] {e}")
+        raise typer.Exit(1)
 
 
 def _apply_headers(header: list[str] | None) -> None:

--- a/src/opensdmx/cli.py
+++ b/src/opensdmx/cli.py
@@ -108,6 +108,72 @@ def _emit(data: object, df: pl.DataFrame | None = None) -> None:
             sys.stdout.write(json.dumps(data, ensure_ascii=False) + "\n")
 
 
+def _write_output(df: pl.DataFrame, out: Path | None) -> None:
+    """Write a frame to stdout as CSV, or to a file chosen by its suffix."""
+    if out is None:
+        sys.stdout.write(df.write_csv())
+        return
+    suffix = out.suffix.lower()
+    if suffix == ".parquet":
+        df.write_parquet(out)
+    elif suffix == ".json":
+        df.write_ndjson(out)
+    elif suffix == ".csv":
+        df.write_csv(out)
+    else:
+        err_console.print(
+            f"[red]Error:[/red] unsupported output format '{suffix}'. Supported: .csv, .parquet, .json"
+        )
+        raise typer.Exit(1)
+    err_console.print(f"[green]Saved:[/green] {out}")
+
+
+def _load_and_filter(dataset_id: str, filters: dict[str, Any]) -> dict[str, Any]:
+    """Load a dataset and apply filters, surfacing any `set_filters` warnings.
+
+    Shared by `get` and `plot` so a suspicious filter value is reported the
+    same way by both.
+    """
+    import warnings as _warnings
+    from . import load_dataset, set_filters
+
+    with console.status("[dim]Loading dataset...[/dim]"):
+        ds: dict[str, Any] = load_dataset(dataset_id)
+        if filters:
+            with _warnings.catch_warnings(record=True) as _caught:
+                _warnings.simplefilter("always")
+                ds = set_filters(ds, **filters)
+            for _w in _caught:
+                err_console.print(f"[yellow]Warning:[/yellow] {_w.message}")
+    return ds
+
+
+def _fetch_frame(
+    ds: dict[str, Any],
+    *,
+    start_period: str | None = None,
+    end_period: str | None = None,
+    last_n: int | None = None,
+    first_n: int | None = None,
+    labels: bool = False,
+) -> pl.DataFrame:
+    """Fetch observations for a prepared dataset, optionally label-enriched."""
+    from . import enrich_with_labels, get_data
+
+    with console.status("[dim]Fetching data...[/dim]"):
+        df: pl.DataFrame = get_data(
+            ds,
+            start_period=start_period,
+            end_period=end_period,
+            last_n_observations=last_n,
+            first_n_observations=first_n,
+        )
+    if labels:
+        with console.status("[dim]Adding labels...[/dim]"):
+            df = enrich_with_labels(ds, df)
+    return df
+
+
 def _version_callback(value: bool) -> None:
     if value:
         from importlib.metadata import version
@@ -1160,20 +1226,12 @@ def get(
     """
     _apply_provider(provider)
     _apply_headers(header)
-    from . import get_data, load_dataset, set_filters
+    from . import get_data
 
     filters = _parse_extra_filters(ctx)
 
     try:
-        import warnings as _warnings
-        with console.status("[dim]Loading dataset...[/dim]"):
-            ds = load_dataset(dataset_id)
-            if filters:
-                with _warnings.catch_warnings(record=True) as _caught:
-                    _warnings.simplefilter("always")
-                    ds = set_filters(ds, **filters)
-                for _w in _caught:
-                    err_console.print(f"[yellow]Warning:[/yellow] {_w.message}")
+        ds = _load_and_filter(dataset_id, filters)
 
         # Probe for large datasets when no last_n/first_n limit is set.
         # Skip if provider does not support lastNObservations (probe would fetch all data).
@@ -1195,13 +1253,14 @@ def get(
             except httpx.HTTPStatusError:
                 pass  # let the real request fail with a proper error
 
-        with console.status("[dim]Fetching data...[/dim]"):
-            df = get_data(ds, start_period=start_period, end_period=end_period,
-                          last_n_observations=last_n, first_n_observations=first_n)
-        if labels:
-            from . import enrich_with_labels
-            with console.status("[dim]Adding labels...[/dim]"):
-                df = enrich_with_labels(ds, df)
+        df = _fetch_frame(
+            ds,
+            start_period=start_period,
+            end_period=end_period,
+            last_n=last_n,
+            first_n=first_n,
+            labels=labels,
+        )
     except httpx.HTTPStatusError as e:
         err_console.print(f"[red]HTTP {e.response.status_code}:[/red] {e.request.url}")
         if e.response.status_code in (400, 404):
@@ -1215,20 +1274,7 @@ def get(
         err_console.print(f"[red]Error:[/red] {e}")
         raise typer.Exit(1)
 
-    if out is None:
-        sys.stdout.write(df.write_csv())
-    else:
-        suffix = out.suffix.lower()
-        if suffix == ".parquet":
-            df.write_parquet(out)
-        elif suffix == ".json":
-            df.write_ndjson(out)
-        elif suffix == ".csv":
-            df.write_csv(out)
-        else:
-            err_console.print(f"[red]Error:[/red] unsupported output format '{suffix}'. Supported: .csv, .parquet, .json")
-            raise typer.Exit(1)
-        err_console.print(f"[green]Saved:[/green] {out}")
+    _write_output(df, out)
 
     if query_file is not None:
         import yaml
@@ -1257,83 +1303,40 @@ def run(
       opensdmx run unemployment.yaml --out results.csv
       opensdmx run query.yaml --out results.parquet
     """
+    import warnings as _warnings
+
     import yaml
-    from . import get_data, load_dataset, set_filters
 
-    if not query_file.exists():
-        err_console.print(f"[red]Error:[/red] file not found: {query_file}")
-        raise typer.Exit(1)
+    from . import run_query
 
-    try:
-        with open(query_file) as fh:
-            q = yaml.safe_load(fh)
-    except Exception as e:
-        err_console.print(f"[red]Error reading YAML:[/red] {e}")
-        raise typer.Exit(1)
-
-    # Provider resolution: CLI flag > alias (if known) > URL + agency_id > env/default
+    # Validate --provider here so an unknown name gets the CLI's readable
+    # error; run_query applies the rest of the precedence chain.
     if provider:
         _apply_provider(provider)
-    else:
-        from .base import PROVIDERS, set_provider
-        alias = q.get("provider")
-        if alias and alias in PROVIDERS:
-            set_provider(alias)
-        elif q.get("provider_url"):
-            set_provider(q["provider_url"], agency_id=q.get("agency_id") or None)
-        else:
-            _apply_provider(None)
-
-    dataset_id = q.get("dataset")
-    if not dataset_id:
-        err_console.print("[red]Error:[/red] 'dataset' field missing in query file")
-        raise typer.Exit(1)
-
-    filters = {dim: info["value"] for dim, info in (q.get("filters") or {}).items()}
-    start_period = q.get("start_period")
-    end_period = q.get("end_period")
-    last_n = q.get("last_n")
-    first_n = q.get("first_n")
 
     try:
-        import warnings as _warnings
-        with console.status("[dim]Loading dataset...[/dim]"):
-            ds = load_dataset(dataset_id)
-            if filters:
-                with _warnings.catch_warnings(record=True) as _caught:
-                    _warnings.simplefilter("always")
-                    ds = set_filters(ds, **filters)
-                for _w in _caught:
-                    err_console.print(f"[yellow]Warning:[/yellow] {_w.message}")
-
-        with console.status("[dim]Fetching data...[/dim]"):
-            df = get_data(ds, start_period=start_period, end_period=end_period,
-                          last_n_observations=last_n, first_n_observations=first_n)
-        if q.get("labels"):
-            from . import enrich_with_labels
-            with console.status("[dim]Adding labels...[/dim]"):
-                df = enrich_with_labels(ds, df)
+        with _warnings.catch_warnings(record=True) as _caught:
+            _warnings.simplefilter("always")
+            with console.status("[dim]Running query...[/dim]"):
+                df = run_query(str(query_file), provider=provider)
+        for _w in _caught:
+            err_console.print(f"[yellow]Warning:[/yellow] {_w.message}")
+    except FileNotFoundError:
+        err_console.print(f"[red]Error:[/red] file not found: {query_file}")
+        raise typer.Exit(1)
+    except yaml.YAMLError as e:
+        err_console.print(f"[red]Error reading YAML:[/red] {e}")
+        raise typer.Exit(1)
     except httpx.HTTPStatusError as e:
         err_console.print(f"[red]HTTP {e.response.status_code}:[/red] {e.request.url}")
         raise typer.Exit(1)
+    except typer.Exit:
+        raise
     except Exception as e:
         err_console.print(f"[red]Error:[/red] {e}")
         raise typer.Exit(1)
 
-    if out is None:
-        sys.stdout.write(df.write_csv())
-    else:
-        suffix = out.suffix.lower()
-        if suffix == ".parquet":
-            df.write_parquet(out)
-        elif suffix == ".json":
-            df.write_ndjson(out)
-        elif suffix == ".csv":
-            df.write_csv(out)
-        else:
-            err_console.print(f"[red]Error:[/red] unsupported format '{suffix}'. Supported: .csv, .parquet, .json")
-            raise typer.Exit(1)
-        err_console.print(f"[green]Saved:[/green] {out}")
+    _write_output(df, out)
 
 
 @app.command(context_settings={"allow_extra_args": True, "ignore_unknown_options": True})
@@ -1425,21 +1428,20 @@ def plot(
             raise typer.Exit(1)
     else:
         _apply_provider(provider)
-        from . import get_data, load_dataset, set_filters
 
         filters = _parse_extra_filters(ctx)
 
         try:
-            ds = load_dataset(dataset_id)
-            if filters:
-                ds = set_filters(ds, **filters)
-            df = get_data(ds, start_period=start_period, end_period=end_period)
+            ds = _load_and_filter(dataset_id, filters)
+            df = _fetch_frame(ds, start_period=start_period, end_period=end_period)
             ds_description = ds["df_description"]
         except httpx.HTTPStatusError as e:
             err_console.print(f"[red]HTTP {e.response.status_code}:[/red] {e.request.url}")
             if e.response.status_code in (400, 404):
                 err_console.print("[yellow]Hint:[/yellow] check filter values with: opensdmx constraints <dataset_id>")
             raise typer.Exit(1)
+        except typer.Exit:
+            raise
         except Exception as e:
             err_console.print(f"[red]Error:[/red] {e}")
             raise typer.Exit(1)

--- a/src/opensdmx/db_cache.py
+++ b/src/opensdmx/db_cache.py
@@ -68,16 +68,6 @@ def _db_conn() -> Iterator[sqlite3.Connection]:
                     cached_at    REAL NOT NULL,
                     PRIMARY KEY (df_id, dimension_id, code_id)
                 );
-                CREATE TABLE IF NOT EXISTS bulk_constraint_fetch (
-                    agency_id TEXT PRIMARY KEY,
-                    cached_at REAL NOT NULL
-                );
-                CREATE TABLE IF NOT EXISTS bulk_constraint_index (
-                    agency_id TEXT NOT NULL,
-                    df_id     TEXT NOT NULL,
-                    cached_at REAL NOT NULL,
-                    PRIMARY KEY (agency_id, df_id)
-                );
             """)
             # In-place migration: add columns missing from a pre-existing
             # codelist_values table (CREATE TABLE IF NOT EXISTS cannot evolve
@@ -270,42 +260,8 @@ def delete_invalid_dataset(df_id: str) -> bool:
         return bool(cur.rowcount > 0)
 
 
-# --- bulk constraint index ---
-
-def is_bulk_constraint_fresh(agency_id: str) -> bool:
-    """Return True if the bulk constraint index for this agency was fetched recently."""
-    with _db_conn() as conn:
-        row = conn.execute(
-            "SELECT cached_at FROM bulk_constraint_fetch WHERE agency_id = ?",
-            (agency_id,),
-        ).fetchone()
-    if row is None:
-        return False
-    return bool(time.time() - row["cached_at"] <= CONSTRAINTS_CACHE_TTL)
-
-
-def get_df_ids_with_content_constraint(agency_id: str) -> set[str] | None:
-    """Return set of short df_ids that have a contentconstraint, or None if index not built."""
-    if not is_bulk_constraint_fresh(agency_id):
-        return None
-    with _db_conn() as conn:
-        rows = conn.execute(
-            "SELECT df_id FROM bulk_constraint_index WHERE agency_id = ?",
-            (agency_id,),
-        ).fetchall()
-    return {row["df_id"] for row in rows}
-
-
-def save_bulk_constraint_index(agency_id: str, df_ids: set[str]) -> None:
-    """Record the set of short df_ids covered by contentconstraint for this agency."""
-    now = time.time()
-    with _db_conn() as conn:
-        conn.execute(
-            "INSERT OR REPLACE INTO bulk_constraint_fetch VALUES (?, ?)",
-            (agency_id, now),
-        )
-        conn.execute("DELETE FROM bulk_constraint_index WHERE agency_id = ?", (agency_id,))
-        conn.executemany(
-            "INSERT OR REPLACE INTO bulk_constraint_index VALUES (?, ?, ?)",
-            [(agency_id, df_id, now) for df_id in df_ids],
-        )
+# The bulk_constraint_fetch / bulk_constraint_index tables lived here. They were
+# written on every catalog rebuild and never read: the only reader was
+# get_df_ids_with_content_constraint(), which had no callers. The signal they
+# carried — whether a dataflow has a contentconstraint — travels in the
+# has_constraint column of dataflows.parquet, which is what discovery reads.

--- a/src/opensdmx/discovery.py
+++ b/src/opensdmx/discovery.py
@@ -151,14 +151,11 @@ def all_available() -> pl.DataFrame:
             cc_content = sdmx_request_xml(cc_path, _timeout=30, _max_retries=1)
             bulk_succeeded = True
             # Use raw long_ids for catalog matching (avoids _DF_ truncation mismatch)
-            long_ids = _extract_bulk_long_ids(cc_content)
-            parsed = _parse_bulk_constraint_xml(cc_content)
-            covered_catalog: set[str] = set()
+            long_ids, parsed = parse_bulk_constraints(cc_content)
             for long_id in long_ids:
                 catalog_id = _match_catalog_id(long_id, catalog_ids)
                 if catalog_id:
                     has_constraint_map[catalog_id] = True
-                    covered_catalog.add(catalog_id)
                     # Cache constraint values under the correct catalog key.
                     # _parse_bulk_constraint_xml uses the short_id (prefix before _DF_)
                     # as the key, so derive it from the long_id for the lookup.
@@ -170,11 +167,6 @@ def all_available() -> pl.DataFrame:
                             save_available_constraints(catalog_id, dims)
                         except Exception as e:
                             logger.warning("Could not cache constraints for %s: %s", catalog_id, e)
-            try:
-                from .db_cache import save_bulk_constraint_index
-                save_bulk_constraint_index(agency_id, covered_catalog)
-            except Exception as e:
-                logger.warning("Could not save bulk constraint index: %s", e)
         except Exception as e:
             logger.warning("Could not fetch bulk constraints at catalog time: %s", e)
 
@@ -747,9 +739,8 @@ def _fallback_availableconstraint(dataset: dict[str, Any], provider: dict[str, A
     return {dim_id: pl.DataFrame({"id": codes}) for dim_id, codes in result.items()}
 
 
-def _extract_bulk_long_ids(content: bytes) -> set[str]:
-    """Extract raw df_ids from bulk contentconstraint XML without any truncation."""
-    root, ns = xml_parse(content)
+def _extract_bulk_long_ids(root: Any, ns: dict[str, str]) -> set[str]:
+    """Extract raw df_ids from a parsed bulk contentconstraint tree, untruncated."""
     struct_ns = ns.get("structure", "")
     cc_tag = f"{{{struct_ns}}}ContentConstraint" if struct_ns else "ContentConstraint"
     result: set[str] = set()
@@ -766,14 +757,25 @@ def _extract_bulk_long_ids(content: bytes) -> set[str]:
     return result
 
 
-def _parse_bulk_constraint_xml(content: bytes) -> dict[str, dict[str, list[str]]]:
-    """Parse a bulk contentconstraint response into {short_df_id: {dim_id: [values]}}.
+def parse_bulk_constraints(
+    content: bytes,
+) -> tuple[set[str], dict[str, dict[str, list[str]]]]:
+    """Parse bulk contentconstraint XML once, returning (long_ids, per-dataflow values).
+
+    Both views come from a single tree build: this is the largest XML the
+    library fetches, and parsing it twice cost two full namespace scans.
+    """
+    root, ns = xml_parse(content)
+    return _extract_bulk_long_ids(root, ns), _parse_bulk_constraint_xml(root, ns)
+
+
+def _parse_bulk_constraint_xml(root: Any, ns: dict[str, str]) -> dict[str, dict[str, list[str]]]:
+    """Parse a parsed bulk contentconstraint tree into {short_df_id: {dim_id: [values]}}.
 
     Merges multiple constraints for the same dataflow by taking the union of values
     per dimension. TIME_PERIOD ranges (TimeRange elements) are silently ignored.
     The short df_id is extracted from the long form by splitting on '_DF_'.
     """
-    root, ns = xml_parse(content)
     struct_ns = ns.get("structure", "")
     common_ns = ns.get("common", "")
 

--- a/src/opensdmx/retrieval.py
+++ b/src/opensdmx/retrieval.py
@@ -167,7 +167,7 @@ def run_query(query_file: str, provider: str | None = None) -> pl.DataFrame:
     """
     import yaml
     from pathlib import Path
-    from .base import PROVIDERS, PROVIDER_ALIASES, set_provider, set_provider_from_env
+    from .base import PROVIDER_ALIASES, PROVIDERS, resolve_provider, set_provider, set_provider_from_env
 
     path = Path(query_file)
     if not path.exists():
@@ -178,9 +178,11 @@ def run_query(query_file: str, provider: str | None = None) -> pl.DataFrame:
 
     alias = q.get("provider")
     if provider:
-        set_provider(PROVIDER_ALIASES.get(provider, provider))
-    elif alias and alias in PROVIDERS:
-        set_provider(alias)
+        # agency_id falls back to OPENSDMX_AGENCY inside resolve_provider, so a
+        # custom --provider URL keeps the agency the CLI already resolved.
+        resolve_provider(provider, agency_id=q.get("agency_id") or None)
+    elif alias and PROVIDER_ALIASES.get(alias, alias) in PROVIDERS:
+        set_provider(PROVIDER_ALIASES[alias] if alias in PROVIDER_ALIASES else alias)
     elif q.get("provider_url"):
         set_provider(q["provider_url"], agency_id=q.get("agency_id") or None)
     else:

--- a/src/opensdmx/retrieval.py
+++ b/src/opensdmx/retrieval.py
@@ -151,18 +151,23 @@ def enrich_with_labels(dataset: dict[str, Any], data: pl.DataFrame) -> pl.DataFr
     return data
 
 
-def run_query(query_file: str) -> pl.DataFrame:
+def run_query(query_file: str, provider: str | None = None) -> pl.DataFrame:
     """Run a query from a YAML file saved with `opensdmx get --query-file`.
+
+    Provider resolution, highest precedence first: the `provider` argument, the
+    file's `provider` alias, its `provider_url`, then the `OPENSDMX_PROVIDER`
+    environment variable. If none apply the active provider is left untouched.
 
     Args:
         query_file: path to the YAML query file
+        provider:   override the provider named in the file
 
     Returns:
         Polars DataFrame
     """
     import yaml
     from pathlib import Path
-    from .base import PROVIDERS, set_provider
+    from .base import PROVIDERS, PROVIDER_ALIASES, set_provider, set_provider_from_env
 
     path = Path(query_file)
     if not path.exists():
@@ -172,10 +177,14 @@ def run_query(query_file: str) -> pl.DataFrame:
         q = yaml.safe_load(fh)
 
     alias = q.get("provider")
-    if alias and alias in PROVIDERS:
+    if provider:
+        set_provider(PROVIDER_ALIASES.get(provider, provider))
+    elif alias and alias in PROVIDERS:
         set_provider(alias)
     elif q.get("provider_url"):
         set_provider(q["provider_url"], agency_id=q.get("agency_id") or None)
+    else:
+        set_provider_from_env()
 
     dataset_id = q.get("dataset")
     if not dataset_id:

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -237,7 +237,6 @@ class TestAllAvailable:
                 patch("opensdmx.discovery._dataflow_cache_path", return_value=cache),
                 patch("opensdmx.discovery._filter_invalid", side_effect=lambda df: df),
                 patch("opensdmx.db_cache.save_available_constraints"),
-                patch("opensdmx.db_cache.save_bulk_constraint_index"),
             ):
                 df = all_available()
         finally:

--- a/tests/test_phase2_dedup.py
+++ b/tests/test_phase2_dedup.py
@@ -105,6 +105,77 @@ def test_run_query_file_provider_wins_over_env(tmp_path, monkeypatch):
     assert seen == [PROVIDERS["eurostat"]["agency_id"]]
 
 
+# ── Review follow-up: provider resolution edge cases ─────────────────
+
+
+def test_resolve_provider_expands_alias():
+    from opensdmx.base import resolve_provider
+
+    set_provider("istat")
+    resolve_provider("estat")
+    assert get_provider()["agency_id"] == PROVIDERS["eurostat"]["agency_id"]
+
+
+def test_resolve_provider_rejects_unknown_name():
+    from opensdmx.base import resolve_provider
+
+    with pytest.raises(ValueError, match="unknown provider 'eurostatt'"):
+        resolve_provider("eurostatt")
+
+
+def test_resolve_provider_accepts_url_with_agency():
+    from opensdmx.base import resolve_provider
+
+    resolve_provider("https://example.org/sdmx", agency_id="MYAG")
+    assert get_provider()["base_url"] == "https://example.org/sdmx"
+    assert get_provider()["agency_id"] == "MYAG"
+
+
+def test_set_provider_from_env_rejects_typo(monkeypatch):
+    """A typo used to become a bogus custom provider and fail later obscurely."""
+    monkeypatch.setenv("OPENSDMX_PROVIDER", "eurostatt")
+    with pytest.raises(ValueError, match="unknown provider"):
+        set_provider_from_env()
+
+
+def test_run_query_file_alias_beats_env(tmp_path, monkeypatch):
+    """`provider: estat` in the file must win over OPENSDMX_PROVIDER."""
+    qfile = _write_query(tmp_path, provider="estat")
+    monkeypatch.setenv("OPENSDMX_PROVIDER", "istat")
+    set_provider("istat")
+
+    seen: list[str] = []
+
+    def spy_load(dataset_id):
+        seen.append(get_provider()["agency_id"])
+        raise RuntimeError("stop")
+
+    with patch("opensdmx.retrieval.load_dataset", side_effect=spy_load):
+        with pytest.raises(RuntimeError):
+            run_query(qfile)
+
+    assert seen == [PROVIDERS["eurostat"]["agency_id"]]
+
+
+def test_run_query_custom_url_keeps_agency(tmp_path, monkeypatch):
+    """`--provider <url>` must not blank the agency the environment supplies."""
+    qfile = _write_query(tmp_path)
+    monkeypatch.setenv("OPENSDMX_AGENCY", "MYAG")
+    monkeypatch.delenv("OPENSDMX_PROVIDER", raising=False)
+
+    seen: list[str] = []
+
+    def spy_load(dataset_id):
+        seen.append(get_provider()["agency_id"])
+        raise RuntimeError("stop")
+
+    with patch("opensdmx.retrieval.load_dataset", side_effect=spy_load):
+        with pytest.raises(RuntimeError):
+            run_query(qfile, provider="https://example.org/sdmx")
+
+    assert seen == ["MYAG"]
+
+
 def test_run_query_missing_file_raises():
     with pytest.raises(FileNotFoundError):
         run_query("/nonexistent/query.yaml")

--- a/tests/test_phase2_dedup.py
+++ b/tests/test_phase2_dedup.py
@@ -1,0 +1,225 @@
+"""Regressions for the v0.14.0 architecture review — Phase 2 deduplication.
+
+See docs/evaluation-v0.14.0.md findings 5, 6, 13, 17.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import polars as pl
+import pytest
+import yaml
+from unittest.mock import patch
+
+from opensdmx import discovery
+from opensdmx.base import PROVIDERS, get_provider, set_provider, set_provider_from_env
+from opensdmx.retrieval import run_query
+
+
+@pytest.fixture(autouse=True)
+def _restore_provider():
+    """Provider is module-global state; put it back after each test."""
+    from opensdmx import base
+
+    saved = base._active_provider
+    yield
+    base._active_provider = saved
+
+
+def _write_query(tmp_path, **extra) -> str:
+    q = {"dataset": "TEST_DF", "filters": {}, **extra}
+    path = tmp_path / "q.yaml"
+    path.write_text(yaml.dump(q))
+    return str(path)
+
+
+# ── Finding 5: run_query lacked the CLI's provider resolution ────────
+
+
+def test_set_provider_from_env_applies_and_resolves_alias(monkeypatch):
+    set_provider("eurostat")
+    monkeypatch.setenv("OPENSDMX_PROVIDER", "istat")
+    assert set_provider_from_env() is True
+    assert get_provider()["agency_id"] == PROVIDERS["istat"]["agency_id"]
+
+
+def test_set_provider_from_env_noop_when_unset(monkeypatch):
+    set_provider("eurostat")
+    monkeypatch.delenv("OPENSDMX_PROVIDER", raising=False)
+    assert set_provider_from_env() is False
+    assert get_provider()["agency_id"] == PROVIDERS["eurostat"]["agency_id"]
+
+
+def test_run_query_honours_env_when_file_has_no_provider(tmp_path, monkeypatch):
+    """The divergence this phase closes: the CLI honoured the env var, the
+    library silently stayed on the default provider."""
+    qfile = _write_query(tmp_path)
+    monkeypatch.setenv("OPENSDMX_PROVIDER", "istat")
+    set_provider("eurostat")
+
+    seen: list[str] = []
+
+    def spy_load(dataset_id):
+        seen.append(get_provider()["agency_id"])
+        raise RuntimeError("stop after provider resolution")
+
+    with patch("opensdmx.retrieval.load_dataset", side_effect=spy_load):
+        with pytest.raises(RuntimeError):
+            run_query(qfile)
+
+    assert seen == [PROVIDERS["istat"]["agency_id"]]
+
+
+def test_run_query_provider_argument_wins_over_file(tmp_path, monkeypatch):
+    qfile = _write_query(tmp_path, provider="eurostat")
+    monkeypatch.delenv("OPENSDMX_PROVIDER", raising=False)
+
+    seen: list[str] = []
+
+    def spy_load(dataset_id):
+        seen.append(get_provider()["agency_id"])
+        raise RuntimeError("stop")
+
+    with patch("opensdmx.retrieval.load_dataset", side_effect=spy_load):
+        with pytest.raises(RuntimeError):
+            run_query(qfile, provider="istat")
+
+    assert seen == [PROVIDERS["istat"]["agency_id"]]
+
+
+def test_run_query_file_provider_wins_over_env(tmp_path, monkeypatch):
+    qfile = _write_query(tmp_path, provider="eurostat")
+    monkeypatch.setenv("OPENSDMX_PROVIDER", "istat")
+
+    seen: list[str] = []
+
+    def spy_load(dataset_id):
+        seen.append(get_provider()["agency_id"])
+        raise RuntimeError("stop")
+
+    with patch("opensdmx.retrieval.load_dataset", side_effect=spy_load):
+        with pytest.raises(RuntimeError):
+            run_query(qfile)
+
+    assert seen == [PROVIDERS["eurostat"]["agency_id"]]
+
+
+def test_run_query_missing_file_raises():
+    with pytest.raises(FileNotFoundError):
+        run_query("/nonexistent/query.yaml")
+
+
+def test_run_query_missing_dataset_field_raises(tmp_path):
+    path = tmp_path / "q.yaml"
+    path.write_text(yaml.dump({"filters": {}}))
+    with pytest.raises(ValueError, match="dataset"):
+        run_query(str(path))
+
+
+# ── Finding 6: plot dropped set_filters warnings that get reported ───
+
+
+def test_load_and_filter_surfaces_set_filters_warnings(capsys):
+    """`plot` used to skip this, so a suspicious filter was silently ignored."""
+    from opensdmx import cli
+
+    def noisy_set_filters(ds, **kwargs):
+        warnings.warn("suspicious filter value", UserWarning)
+        return ds
+
+    with (
+        patch("opensdmx.load_dataset", return_value={"df_id": "X", "dimensions": {}}),
+        patch("opensdmx.set_filters", side_effect=noisy_set_filters),
+    ):
+        cli._load_and_filter("X", {"geo": "ZZ"})
+
+    assert "suspicious filter value" in capsys.readouterr().err
+
+
+def test_load_and_filter_skips_set_filters_when_no_filters():
+    from opensdmx import cli
+
+    with (
+        patch("opensdmx.load_dataset", return_value={"df_id": "X"}),
+        patch("opensdmx.set_filters") as sf,
+    ):
+        cli._load_and_filter("X", {})
+    sf.assert_not_called()
+
+
+# ── Shared output writer ─────────────────────────────────────────────
+
+
+def test_write_output_dispatches_on_suffix(tmp_path):
+    from opensdmx import cli
+
+    df = pl.DataFrame({"a": [1, 2]})
+    for suffix, reader in ((".csv", pl.read_csv), (".parquet", pl.read_parquet)):
+        out = tmp_path / f"data{suffix}"
+        cli._write_output(df, out)
+        assert reader(out).height == 2
+
+
+def test_write_output_rejects_unknown_suffix(tmp_path, capsys):
+    import typer
+
+    from opensdmx import cli
+
+    with pytest.raises(typer.Exit):
+        cli._write_output(pl.DataFrame({"a": [1]}), tmp_path / "data.xlsx")
+    assert "unsupported output format" in capsys.readouterr().err
+
+
+def test_write_output_to_stdout_when_out_is_none(capsys):
+    from opensdmx import cli
+
+    cli._write_output(pl.DataFrame({"a": ["v, w"]}), None)
+    assert '"v, w"' in capsys.readouterr().out
+
+
+# ── Finding 17: the bulk contentconstraint XML was parsed twice ──────
+
+_CC_XML = b"""<?xml version="1.0" encoding="UTF-8"?>
+<mes:Structure xmlns:mes="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/message"
+               xmlns:str="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/structure"
+               xmlns:com="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/common">
+  <mes:Structures>
+    <str:ContentConstraints>
+      <str:ContentConstraint id="CC1">
+        <str:ConstraintAttachment>
+          <str:Dataflow><Ref id="12_60_DF_DCCV_CONSACQUA_2"/></str:Dataflow>
+        </str:ConstraintAttachment>
+        <str:CubeRegion>
+          <com:KeyValue id="REF_AREA">
+            <com:Value>IT</com:Value>
+            <com:Value>ITC1</com:Value>
+          </com:KeyValue>
+        </str:CubeRegion>
+      </str:ContentConstraint>
+    </str:ContentConstraints>
+  </mes:Structures>
+</mes:Structure>"""
+
+
+def test_parse_bulk_constraints_returns_both_views():
+    long_ids, parsed = discovery.parse_bulk_constraints(_CC_XML)
+    assert long_ids == {"12_60_DF_DCCV_CONSACQUA_2"}
+    assert parsed == {"12_60": {"REF_AREA": ["IT", "ITC1"]}}
+
+
+def test_parse_bulk_constraints_builds_the_tree_once():
+    """The whole point: one xml_parse call, not two."""
+    with patch(
+        "opensdmx.discovery.xml_parse", wraps=discovery.xml_parse
+    ) as spy:
+        discovery.parse_bulk_constraints(_CC_XML)
+    assert spy.call_count == 1
+
+
+def test_parse_bulk_constraints_tolerates_empty_document():
+    long_ids, parsed = discovery.parse_bulk_constraints(
+        b'<?xml version="1.0"?><root/>'
+    )
+    assert long_ids == set()
+    assert parsed == {}


### PR DESCRIPTION
Phase 2 of `docs/evaluation-v0.14.0.md`. Four places where the same logic was written twice or three times, with copies that had already started to diverge. No functional change except the one flagged below.

## `run` reimplemented `run_query()`

`retrieval.run_query()` is public API, exported in `__all__`. The CLI command did not call it — it kept its own copy, and the two had drifted:

| | CLI `run` | `run_query` (before) |
|---|---|---|
| `--provider` flag | yes | absent |
| `OPENSDMX_PROVIDER` fallback | yes | **absent** |
| `set_filters` warnings | captured | ignored |

The second row is the one that mattered: **the same YAML file behaved differently depending on who ran it.** With no `provider` field, the CLI honoured the environment while the library silently stayed on eurostat — and the library is what downstream importers get.

`run_query()` now takes `provider=` and falls back to the environment. Precedence: argument → file `provider` alias → file `provider_url` → `OPENSDMX_PROVIDER` → leave as-is.

> ⚠️ **Behaviour change for library users.** A query file with no `provider` field now respects `OPENSDMX_PROVIDER` instead of ignoring it. This aligns the library with the CLI; the previous divergence was effectively a bug. Agreed as a fix rather than an opt-in flag.

New `base.set_provider_from_env()` resolves the variable including aliases — `set_provider()` alone never did, which is exactly why the CLI had grown its own path.

## Three fetch blocks, one already degraded

`load_dataset → set_filters → get_data → enrich_with_labels` appeared in `get`, `run` and `plot`. Counting `catch_warnings` in `cli.py` returned **2**, not 3 — `plot` was missing it. So a suspicious filter value was reported by `get` and silently swallowed by `plot`.

Extracted `_load_and_filter()` and `_fetch_frame()`. Verified live — `plot` now prints `Dimension 'na-item' not found. Ignoring.` where before it said nothing.

The output-writing block was likewise duplicated between `get` and `run`, differing by one word in the error string (`unsupported output format` vs `unsupported format`) — the signature of hand-copying. Extracted `_write_output()`.

## The largest XML was parsed twice

`_extract_bulk_long_ids` and `_parse_bulk_constraint_xml` each called `xml_parse()` on the same bulk contentconstraint bytes — two full tree builds plus two full-tree namespace scans of the biggest document the library ever fetches. `parse_bulk_constraints()` now returns both views from one pass, with a test asserting `xml_parse` is called exactly once.

## Two SQLite tables written and never read

`bulk_constraint_fetch` and `bulk_constraint_index` formed a closed loop: `is_bulk_constraint_fresh` was called only by `get_df_ids_with_content_constraint`, which had no callers at all. Meanwhile the write path ran on every catalog rebuild. The signal they would have served, `has_constraint`, already travels in the `dataflows.parquet` column that `discovery.py` actually reads.

Deleted, along with their schema. The stale `docs/cache.md` entry is folded into the Phase 4 docs pass.

## Verification

- 243 → **258 tests**, 15 new in `tests/test_phase2_dedup.py`
- `ruff check src/` clean, `mypy --strict` green on 14 modules
- Real-CLI smoke: `get --query-file` → `run` round-trip against Eurostat, and `plot` producing a PNG
- Net `src/`: 154 insertions, 166 deletions

One existing test broke — it patched the deleted `save_bulk_constraint_index`. Updated rather than worked around.

## Noted, not fixed

Found while smoke-testing and **confirmed pre-existing** against released v0.14.1: `--na-item` (dash) does not map to the `na_item` dimension. `set_filters` warns on stderr and proceeds unfiltered — so an agent reading stdout alone gets unfiltered data with no signal. Deserves its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)