### PR TITLE
fix!: match filter names on dash/underscore, reject unknown ones

### DIFF
--- a/LOG.md
+++ b/LOG.md
@@ -1,5 +1,14 @@
 # LOG
 
+## 2026-07-18 - v0.15.0 - strict filter matching
+
+- fix(discovery): `set_filters` now treats `-` and `_` as equivalent when matching dimension names, so `--na-item` reaches the `NA_ITEM` dimension. CLI convention is dashes, SDMX ids use underscores; matching was already case-insensitive, this extends the same leniency.
+- **BREAKING** fix(discovery): an unknown filter name now raises `ValueError` instead of being dropped with a log line. The old behaviour ran the query unfiltered and put the only signal on stderr — for a tool whose primary consumer reads stdout, that returned wrong data with no indication. Verified: `opensdmx get NAMA_10_GDP --geo IT --na-item B1GQ ...` used to emit 20+ `na_item` values when one was asked for. The error carries a `difflib` suggestion and the available dimension list.
+- **Correction to the Phase 2 record.** That refactor claimed `plot` had degraded by not capturing `set_filters` warnings. It had not. `catch_warnings` genuinely appeared in `get`/`run` and not `plot`, but **nothing in the package calls `warnings.warn`** — the messages come from `logger.warning` via logging, independently. Confirmed by running `plot` at the v0.14.1 tag: same output. The claim was verified only in the after state, never the before.
+- refactor(cli): removed the dead `catch_warnings` blocks from `_load_and_filter` and `run`. They captured nothing, and Phase 2 had preserved them faithfully rather than deleting them — the opposite of that phase's purpose.
+- test: replaced `test_load_and_filter_surfaces_set_filters_warnings`, which passed only because its own mock raised a warning the real code never raises. 5 new tests on dash matching, the raise, the suggestion and the available list. Suite 264 → 268.
+- docs: `docs/evaluation-v0.14.0.md` finding 6 carries the correction inline; new finding 20 documents the filter bug.
+
 ## 2026-07-18 - Phase 2: remove duplication
 
 - refactor(retrieval, cli): `opensdmx run` reimplemented `retrieval.run_query()` — public API, exported in `__all__` — and the copies had diverged. The CLI honoured `OPENSDMX_PROVIDER` and accepted `--provider`; the library did neither, so the same YAML file behaved differently depending on the caller. `run_query()` gains a `provider` argument and the env fallback; the CLI now calls it. **Behaviour change for library users**: a query file with no `provider` field now respects `OPENSDMX_PROVIDER` instead of silently staying on the default.

--- a/docs/evaluation-v0.14.0.md
+++ b/docs/evaluation-v0.14.0.md
@@ -136,9 +136,17 @@ The correct shape is to **share the transport hygiene without sharing the rate-l
 
 Two implementations of one behaviour, already out of sync, with the library version being the weaker one — that is the version a downstream importer gets.
 
-**6. The same fetch block is written three times, and the third copy is degraded.** `cli.py:1156-1192`, `1282-1299`, `1416-1421`
+**6. The same fetch block is written three times.** `cli.py:1156-1192`, `1282-1299`, `1416-1421`
 
-`load_dataset → set_filters → get_data → enrich_with_labels` appears in `get`, `run` and `plot`. The `plot` copy does **not** capture `set_filters` warnings, so a suspicious filter value is reported by `get` and silently ignored by `plot`. The output-writing block is likewise duplicated between `get` and `run`, where the error strings differ by one word (`unsupported output format` vs `unsupported format`) — evidence of hand-copying.
+`load_dataset → set_filters → get_data → enrich_with_labels` appears in `get`, `run` and `plot`. The output-writing block is likewise duplicated between `get` and `run`, where the error strings differ by one word (`unsupported output format` vs `unsupported format`) — evidence of hand-copying.
+
+> **Correction.** This finding originally claimed the `plot` copy was *degraded* — that it did not capture `set_filters` warnings, so a suspicious filter reported by `get` was silently ignored by `plot`. **That was wrong**, and it survived into the Phase 2 commit and PR #50 before being caught.
+>
+> The observation behind it was real: `catch_warnings` appeared twice in `cli.py`, in `get` and `run`, not in `plot`. The inference was not. **Nothing in the package calls `warnings.warn`** — `set_filters` used `logger.warning`, which reaches stderr through logging regardless of any `catch_warnings` block. Verified by running `plot` against the v0.14.1 tag: it printed `Dimension 'na-item' not found. Ignoring.` before the refactor as well.
+>
+> Two lessons. First, the `catch_warnings` machinery in `get` and `run` was dead code from the start — Phase 2 preserved it faithfully instead of deleting it, which is the opposite of that phase's purpose. Second, the verification that "confirmed" the fix only exercised the *after* state; the same session had correctly established the `--na-item` behaviour as pre-existing precisely by testing *before* as well.
+>
+> The deduplication in Phase 2 stands on its own merits. Only this rationale was wrong. The dead `catch_warnings` blocks were removed in the follow-up that also made unknown filters raise (finding 20).
 
 **7. Packaging metadata is wrong in two directions.** `pyproject.toml`
 
@@ -196,6 +204,21 @@ The semantic branch returns at line 265; the category filter and all pagination 
 **18. Eager numpy costs 45 ms on every invocation.** `__init__.py:26` → `embed.py:8`
 
 Measured: 282 ms import, 238 ms with numpy stubbed. Paid by `--help`, `get` and `search`, none of which touch numpy. The module already uses lazy imports for `ollama`; applying the same to numpy recovers 16% of import time. The remaining ~240 ms is polars, httpx, rich and typer — genuinely needed.
+
+**20. An unknown filter name returned unfiltered data, with the only signal on stderr.** `discovery.py:940`
+
+Found during Phase 2 smoke-testing, not by the review itself, and pre-existing — reproduced against the released v0.14.1.
+
+`set_filters` matched dimension names case-insensitively but not dash-insensitively, so `--na-item` did not match the `NA_ITEM` dimension. The unmatched filter was then dropped with a `logger.warning` and the query ran unfiltered:
+
+```
+$ opensdmx get NAMA_10_GDP --geo IT --na-item B1GQ --unit CP_MEUR --freq A --last-n 1
+# stdout carries 20+ na_item values; only B1GQ was asked for
+```
+
+Two defects compounding. The dash/underscore mismatch is a usability gap: CLI convention is dashes, SDMX ids use underscores, and `--na-item` is what a user naturally types. The silent drop is the dangerous half — for a tool whose stated primary consumer is an agent reading stdout, returning the wrong data with the only signal on stderr is a correctness hazard, and it applied to *any* misspelled dimension, not just dashed ones.
+
+Fixed by normalising `-` to `_` when matching, and by raising `ValueError` (with a `difflib` did-you-mean and the list of available dimensions) instead of dropping. Behaviour change on public API, so it ships in a minor version.
 
 **19. `docs/architecture.md` is stale.** Module map omits `hub.py`, `categories.py`, `guide.py`, `which.py`, `cache_config.py` — 1.092 lines, roughly 20% of the package, including the distinctive ISTAT hub path. It also contradicts itself on the cache directory: `~/.cache/opensdmx/eurostat/` in one section, `{agency_id}` in another. The code (`base.py:156`) uses the **preset name** for preset providers and `agency_id` only for custom ones, so the second statement is wrong.
 
@@ -287,3 +310,4 @@ These were examined and found sound. Several look like problems at first glance.
 | 17 | `discovery.py:154-155` | Largest XML parsed twice | Medium |
 | 18 | `__init__.py:26` | Eager numpy costs 45 ms per invocation | Low-medium |
 | 19 | `docs/architecture.md` | 5 modules missing; cache-dir self-contradiction | Low |
+| 20 | `discovery.py:940` | An unknown filter name was dropped with a log line, silently returning unfiltered data on stdout | **High** (found after the review, during Phase 2 smoke-testing) |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "opensdmx"
-version = "0.14.1"
+version = "0.15.0"
 description = "Simple Python interface to any SDMX 2.1 REST API (Eurostat, ISTAT, and more)"
 readme = "README.md"
 authors = [

--- a/skills/sdmx-explorer/SKILL.md
+++ b/skills/sdmx-explorer/SKILL.md
@@ -484,6 +484,19 @@ know are valid and `opensdmx constraints` doesn't provide enough detail.
 **Never use `opensdmx values` to validate filter codes.** A code present in the codelist
 may return no data if it doesn't exist in this specific dataflow.
 
+**Filter names (v0.15.0+).** Dimension names match case-insensitively, and `-` and `_`
+are equivalent — `--na-item`, `--na_item` and `--NA_ITEM` all reach `NA_ITEM`. A name
+matching no dimension is a hard error listing the available ones, often with a
+suggestion:
+
+```
+Error: unknown dimension(s): 'geoo' (did you mean 'geo'?). Available: freq, unit, na_item, geo
+```
+
+Read that list and retry — do not ignore the error. Before v0.15.0 an unrecognised
+filter was dropped with a warning on stderr and the query ran **unfiltered**, so stdout
+carried more data than requested with no signal in it.
+
 **Codelist hierarchy (library API).** When a codelist is hierarchical or ordered, the
 Python accessor `opensdmx.get_codelist_hierarchy(ds, dim)` returns `(id, name, parent,
 order)` — useful to filter by geographic level, roll up child→parent, or sort in the

--- a/src/opensdmx/cli.py
+++ b/src/opensdmx/cli.py
@@ -129,10 +129,11 @@ def _write_output(df: pl.DataFrame, out: Path | None) -> None:
 
 
 def _load_and_filter(dataset_id: str, filters: dict[str, Any]) -> dict[str, Any]:
-    """Load a dataset and apply filters, surfacing any `set_filters` warnings.
+    """Load a dataset and apply filters.
 
-    Shared by `get` and `plot` so a suspicious filter value is reported the
-    same way by both.
+    Shared by `get` and `plot` so both reject a bad filter identically.
+    `set_filters` raises `ValueError` on an unknown dimension name; the
+    caller turns that into a CLI error rather than querying unfiltered.
     """
     from . import load_dataset, set_filters
 

--- a/src/opensdmx/cli.py
+++ b/src/opensdmx/cli.py
@@ -134,17 +134,12 @@ def _load_and_filter(dataset_id: str, filters: dict[str, Any]) -> dict[str, Any]
     Shared by `get` and `plot` so a suspicious filter value is reported the
     same way by both.
     """
-    import warnings as _warnings
     from . import load_dataset, set_filters
 
     with console.status("[dim]Loading dataset...[/dim]"):
         ds: dict[str, Any] = load_dataset(dataset_id)
         if filters:
-            with _warnings.catch_warnings(record=True) as _caught:
-                _warnings.simplefilter("always")
-                ds = set_filters(ds, **filters)
-            for _w in _caught:
-                err_console.print(f"[yellow]Warning:[/yellow] {_w.message}")
+            ds = set_filters(ds, **filters)
     return ds
 
 
@@ -1304,8 +1299,6 @@ def run(
       opensdmx run unemployment.yaml --out results.csv
       opensdmx run query.yaml --out results.parquet
     """
-    import warnings as _warnings
-
     import yaml
 
     from . import run_query
@@ -1316,12 +1309,8 @@ def run(
         _apply_provider(provider)
 
     try:
-        with _warnings.catch_warnings(record=True) as _caught:
-            _warnings.simplefilter("always")
-            with console.status("[dim]Running query...[/dim]"):
-                df = run_query(str(query_file), provider=provider)
-        for _w in _caught:
-            err_console.print(f"[yellow]Warning:[/yellow] {_w.message}")
+        with console.status("[dim]Running query...[/dim]"):
+            df = run_query(str(query_file), provider=provider)
     except FileNotFoundError:
         err_console.print(f"[red]Error:[/red] file not found: {query_file}")
         raise typer.Exit(1)

--- a/src/opensdmx/discovery.py
+++ b/src/opensdmx/discovery.py
@@ -959,11 +959,28 @@ def set_filters(dataset: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
     """
     import copy
     dataset = copy.deepcopy(dataset)
-    dim_norm = {_normalise_dim(k): k for k in dataset["dimensions"]}
+    dims = list(dataset["dimensions"])
+
+    # A dimension id may legally contain '-' (SDMX ids are NCNames), so two
+    # dimensions such as A-B and A_B can share a normalised form. No provider
+    # in the wild does this — 441 dimension ids across 7 providers, none with
+    # a dash — but the collision must not resolve to whichever came first.
+    #
+    # Matching the exact (case-insensitive) id before the normalised one makes
+    # that unreachable rather than merely detected: any key normalising to a
+    # colliding form is itself one of the colliding ids up to case, so the
+    # exact pass always claims it. Both stay independently addressable.
+    exact = {d.upper(): d for d in dims}
+    by_norm: dict[str, list[str]] = {}
+    for dim in dims:
+        by_norm.setdefault(_normalise_dim(dim), []).append(dim)
 
     unknown: list[str] = []
     for key, value in kwargs.items():
-        actual = dim_norm.get(_normalise_dim(key))
+        actual = exact.get(key.upper())
+        if actual is None:
+            candidates = by_norm.get(_normalise_dim(key), [])
+            actual = candidates[0] if len(candidates) == 1 else None
         if actual is None:
             unknown.append(key)
             continue
@@ -979,7 +996,7 @@ def set_filters(dataset: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
                 _normalise_dim(key), [_normalise_dim(d) for d in available], n=1
             )
             if close:
-                suggestion = dim_norm[close[0]]
+                suggestion = by_norm[close[0]][0]
                 details.append(f"'{key}' (did you mean '{suggestion}'?)")
             else:
                 details.append(f"'{key}'")

--- a/src/opensdmx/discovery.py
+++ b/src/opensdmx/discovery.py
@@ -937,18 +937,56 @@ def get_available_values(dataset: dict[str, Any]) -> dict[str, pl.DataFrame]:
     return {dim_id: pl.DataFrame({"id": codes}) for dim_id, codes in result.items()}
 
 
+def _normalise_dim(name: str) -> str:
+    """Normalise a dimension name for matching: upper-case, '-' same as '_'.
+
+    SDMX dimension ids use underscores (NA_ITEM, TIME_PERIOD); CLI convention
+    is dashes. Treating them as equivalent lets `--na-item` and `--na_item`
+    both work, the same way matching is already case-insensitive.
+    """
+    return name.upper().replace("-", "_")
+
+
 def set_filters(dataset: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
-    """Set dimension filters (case-insensitive). Returns a new dataset dict."""
+    """Set dimension filters. Returns a new dataset dict.
+
+    Matching is case-insensitive and treats '-' and '_' as equivalent.
+
+    Raises:
+        ValueError: if a name matches no dimension. Unknown filters used to be
+            dropped with a log line, which meant a typo silently returned
+            unfiltered data — the wrong answer, with the only signal on stderr.
+    """
     import copy
     dataset = copy.deepcopy(dataset)
-    dim_upper = {k.upper(): k for k in dataset["dimensions"]}
+    dim_norm = {_normalise_dim(k): k for k in dataset["dimensions"]}
 
+    unknown: list[str] = []
     for key, value in kwargs.items():
-        actual = dim_upper.get(key.upper())
+        actual = dim_norm.get(_normalise_dim(key))
         if actual is None:
-            logger.warning("Dimension '%s' not found. Ignoring.", key)
+            unknown.append(key)
             continue
         dataset["filters"][actual] = value
+
+    if unknown:
+        import difflib
+
+        available = list(dataset["dimensions"])
+        details = []
+        for key in unknown:
+            close = difflib.get_close_matches(
+                _normalise_dim(key), [_normalise_dim(d) for d in available], n=1
+            )
+            if close:
+                suggestion = dim_norm[close[0]]
+                details.append(f"'{key}' (did you mean '{suggestion}'?)")
+            else:
+                details.append(f"'{key}'")
+        raise ValueError(
+            f"unknown dimension(s): {', '.join(details)}. "
+            f"Available: {', '.join(available)}"
+        )
 
     return dataset
 

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -91,6 +91,29 @@ def test_set_filters_underscore_still_works():
     assert set_filters(ds, na_item="B1GQ")["filters"]["NA_ITEM"] == "B1GQ"
 
 
+def test_set_filters_exact_id_wins_over_normalised_collision():
+    """SDMX ids are NCNames, so 'A-B' and 'A_B' may coexist and share a
+    normalised form. Matching the exact id first keeps both addressable and
+    stops the pair resolving to whichever was declared first."""
+    ds = _make_dataset(**{"A-B": 0, "A_B": 1})
+    assert set_filters(ds, **{"A-B": "X"})["filters"]["A-B"] == "X"
+    assert set_filters(ds, **{"A_B": "Y"})["filters"]["A_B"] == "Y"
+
+
+def test_set_filters_collision_resolves_case_insensitively():
+    ds = _make_dataset(**{"A-B": 0, "A_B": 1})
+    lower_dash = set_filters(ds, **{"a-b": "X"})["filters"]
+    assert lower_dash["A-B"] == "X" and lower_dash["A_B"] == "."
+    lower_under = set_filters(ds, **{"a_b": "Y"})["filters"]
+    assert lower_under["A_B"] == "Y" and lower_under["A-B"] == "."
+
+
+def test_set_filters_collision_does_not_break_other_dimensions():
+    """A dataset merely containing such a pair stays usable."""
+    ds = _make_dataset(**{"A-B": 0, "A_B": 1, "GEO": 2})
+    assert set_filters(ds, geo="IT")["filters"]["GEO"] == "IT"
+
+
 # ── get_dimension_values ─────────────────────────────────────────────
 
 def test_get_dimension_values_case_insensitive():

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -53,13 +53,42 @@ def test_set_filters_list_value():
     assert result["filters"]["GEO"] == ["IT", "FR", "DE"]
 
 
-def test_set_filters_unknown_dimension_warns(caplog):
-    import logging
+def test_set_filters_unknown_dimension_raises():
+    """Unknown filters used to be dropped with a log line, which silently
+    returned unfiltered data. They now fail loudly."""
+    import pytest
+
     ds = _make_dataset(FREQ=0)
-    with caplog.at_level(logging.WARNING, logger="opensdmx.discovery"):
-        result = set_filters(ds, NONEXISTENT="X")
-    assert any("NONEXISTENT" in r.message for r in caplog.records)
-    assert "NONEXISTENT" not in result["filters"]
+    with pytest.raises(ValueError, match="NONEXISTENT"):
+        set_filters(ds, NONEXISTENT="X")
+
+
+def test_set_filters_unknown_dimension_lists_available():
+    import pytest
+
+    ds = _make_dataset(FREQ=0)
+    with pytest.raises(ValueError, match="Available: FREQ"):
+        set_filters(ds, NONEXISTENT="X")
+
+
+def test_set_filters_suggests_close_match():
+    import pytest
+
+    ds = _make_dataset(FREQ=0)
+    with pytest.raises(ValueError, match="did you mean 'FREQ'"):
+        set_filters(ds, FREQQ="A")
+
+
+def test_set_filters_dash_matches_underscore():
+    """CLI convention is dashes, SDMX ids use underscores."""
+    ds = _make_dataset(NA_ITEM=0)
+    result = set_filters(ds, **{"na-item": "B1GQ"})
+    assert result["filters"]["NA_ITEM"] == "B1GQ"
+
+
+def test_set_filters_underscore_still_works():
+    ds = _make_dataset(NA_ITEM=0)
+    assert set_filters(ds, na_item="B1GQ")["filters"]["NA_ITEM"] == "B1GQ"
 
 
 # ── get_dimension_values ─────────────────────────────────────────────

--- a/tests/test_phase2_dedup.py
+++ b/tests/test_phase2_dedup.py
@@ -5,7 +5,6 @@ See docs/evaluation-v0.14.0.md findings 5, 6, 13, 17.
 
 from __future__ import annotations
 
-import warnings
 
 import polars as pl
 import pytest
@@ -188,24 +187,28 @@ def test_run_query_missing_dataset_field_raises(tmp_path):
         run_query(str(path))
 
 
-# ── Finding 6: plot dropped set_filters warnings that get reported ───
+# ── Finding 6 (corrected): filter errors must reach the caller ───────
 
 
-def test_load_and_filter_surfaces_set_filters_warnings(capsys):
-    """`plot` used to skip this, so a suspicious filter was silently ignored."""
+def test_load_and_filter_propagates_set_filters_error():
+    """A bad filter must reach the caller, which turns it into a CLI error.
+
+    This replaces a test that asserted `warnings.warn` output was captured.
+    That test passed only because its mock raised a warning: nothing in the
+    package uses the warnings module, so the machinery it exercised never
+    fired in production. See docs/evaluation-v0.14.0.md, finding 6.
+    """
     from opensdmx import cli
 
-    def noisy_set_filters(ds, **kwargs):
-        warnings.warn("suspicious filter value", UserWarning)
-        return ds
+    def strict_set_filters(ds, **kwargs):
+        raise ValueError("unknown dimension(s): 'geoo'")
 
     with (
         patch("opensdmx.load_dataset", return_value={"df_id": "X", "dimensions": {}}),
-        patch("opensdmx.set_filters", side_effect=noisy_set_filters),
+        patch("opensdmx.set_filters", side_effect=strict_set_filters),
     ):
-        cli._load_and_filter("X", {"geo": "ZZ"})
-
-    assert "suspicious filter value" in capsys.readouterr().err
+        with pytest.raises(ValueError, match="geoo"):
+            cli._load_and_filter("X", {"geoo": "IT"})
 
 
 def test_load_and_filter_skips_set_filters_when_no_filters():

--- a/uv.lock
+++ b/uv.lock
@@ -1137,7 +1137,7 @@ wheels = [
 
 [[package]]
 name = "opensdmx"
-version = "0.14.1"
+version = "0.15.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx", extra = ["socks"] },


### PR DESCRIPTION
Closes the `--na-item` bug found while smoke-testing #50, and corrects a claim I got wrong in that PR.

> **BREAKING** — `set_filters()` raises `ValueError` on an unknown dimension name instead of dropping it. Ships as `0.15.0`.

## The bug

`set_filters` matched dimension names case-insensitively but **not** dash-insensitively, so `--na-item` never reached the `NA_ITEM` dimension. The unmatched filter was then dropped with a `logger.warning` and the query ran unfiltered:

```
$ opensdmx get NAMA_10_GDP --geo IT --na-item B1GQ --unit CP_MEUR --freq A --last-n 1
# stdout: B1G, B1GQ, B2A3G, D1, D11, D12, D2, D21, ... 20+ na_item values
```

Two defects compounding:

- **Dash vs underscore** is a usability gap. CLI convention is dashes, SDMX ids use underscores, and `--na-item` is what a user naturally types.
- **The silent drop is the dangerous half**, and it applied to *any* misspelled dimension. For a tool whose stated primary consumer is an agent reading stdout, returning the wrong data with the only signal on stderr is a correctness hazard.

Pre-existing — reproduced against the released v0.14.1, not introduced by #50.

## The fix

Matching normalises `-` to `_`, extending the leniency already applied to case. An unmatched name raises, carrying a `difflib` suggestion and the available dimensions:

```
$ opensdmx get NAMA_10_GDP --geoo IT --last-n 1
Error: unknown dimension(s): 'geoo' (did you mean 'geo'?). Available: freq, unit, na_item, geo
$ echo $?
1
```

Verified live: `--na-item B1GQ` now returns B1GQ alone; a valid query still exits 0.

## Correction to the Phase 2 record

PR #50 claimed the `plot` copy of the fetch block had *degraded* by not capturing `set_filters` warnings. **That was wrong.**

The observation behind it was real — `catch_warnings` appeared in `get` and `run`, not in `plot`. The inference was not: **nothing in this package calls `warnings.warn`.** `set_filters` used `logger.warning`, which reaches stderr through logging regardless of any `catch_warnings` block. Confirmed by running `plot` at the `v0.14.1` tag — identical output, before the refactor.

The verification that "confirmed" the fix only exercised the *after* state. The `--na-item` question in the same session was established correctly as pre-existing precisely *because* the before state was tested too.

Two consequences, both handled here:

- The `catch_warnings` blocks were dead code from the start, and Phase 2 preserved them faithfully rather than deleting them — the opposite of that phase's purpose. **Removed.**
- `test_load_and_filter_surfaces_set_filters_warnings` passed only because its own mock raised a warning the real code never raises. **Replaced** with one asserting the error propagates.

The deduplication in #50 stands on its own merits; only that one rationale was wrong.

## Docs

- `docs/evaluation-v0.14.0.md` — correction inline under finding 6; new finding 20 for the filter bug
- `skills/sdmx-explorer/SKILL.md` — documents the matching rules and tells the agent to read the error rather than ignore it
- `LOG.md`, version → `0.15.0`

## Verification

- 264 → **268 tests**; 5 new on dash matching, the raise, the suggestion, the available list
- `ruff check src/` clean, `mypy --strict` green on 14 modules
- Real CLI, both paths, exit codes checked

🤖 Generated with [Claude Code](https://claude.com/claude-code)