### PR TITLE
fix!: tree no longer drops flags silently without --scheme

### DIFF
--- a/LOG.md
+++ b/LOG.md
@@ -1,5 +1,14 @@
 # LOG
 
+## 2026-07-20 - tree: stop dropping flags silently
+
+- **BREAKING** fix(cli): `tree --category X` and `tree --show-dataflows` without `--scheme` now exit 1 instead of silently printing the scheme list with exit 0. The `scheme is None` branch returned before any tree-shaping flag was read, so three flags were accepted and discarded — `--category`'s own help text already claimed "requires --scheme", an intent never enforced.
+- feat(cli): `--depth` now acts without `--scheme`. The provider is the root of the tree and the scheme list is level 1, so `--depth N` uniformly means "N levels below the current root" and the special case disappears. `--depth 2` renders one tree per scheme with its top-level categories; ISTAT goes from 45 to 314 lines. `--depth 1` and the no-flag default keep printing the same scheme table — deliberate, since `skills/sdmx-explorer` documents `tree --depth 1` as the entry point of the guided workflow.
+- refactor(cli): the ASCII render block moved into `_render_tree_block()` so the no-scheme path reuses it per scheme rather than reimplementing it.
+- Rendering shifts with depth: level 1 is the `n_df` table, level 2+ the ASCII tree. Accepted, no row-count warning — whoever types `--depth 3` asked for the big tree.
+- test: 5 new cases in `tests/test_cli.py`, including a regression guard that no-scheme `--depth 1` output stays identical to the no-flag output, and a dedicated two-scheme fixture covering the one-tree-per-scheme loop the single-scheme fixture could not reach. Suite 271 → 276.
+- docs: `tree` docstring and `skills/sdmx-explorer/SKILL.md` state the root/level model; plan in `tasks/todo-tree-depth.md`.
+
 ## 2026-07-18 - v0.15.0 - strict filter matching
 
 - fix(discovery): `set_filters` now treats `-` and `_` as equivalent when matching dimension names, so `--na-item` reaches the `NA_ITEM` dimension. CLI convention is dashes, SDMX ids use underscores; matching was already case-insensitive, this extends the same leniency.

--- a/skills/sdmx-explorer/SKILL.md
+++ b/skills/sdmx-explorer/SKILL.md
@@ -180,9 +180,14 @@ opensdmx tree --scheme Z0400PRI --category PRI_CONWHONAT --provider istat --dept
 opensdmx search "" --category DCSP_NIC1B2015 --provider istat
 ```
 
-`--depth` is **relative to `--category`** when `--category` is set: `--depth 1`
-always means "the node plus its direct children", regardless of the category's
-absolute depth in the tree.
+`--depth N` always means "N levels below the current root". The root is the
+category when `--category` is set, the scheme when only `--scheme` is set, and
+the provider itself when neither is: that is why `tree --depth 1` with no
+`--scheme` lists the schemes, and `--depth 2` would add their top-level
+categories. Prefer `--depth 1` and let the user pick the branch.
+
+`--category` and `--show-dataflows` are scheme-scoped: without `--scheme` they
+exit with an error rather than being silently ignored.
 
 After each step, present the children to the user in plain language and ask
 which branch to explore next. Do not pre-emptively dive deeper than one level

--- a/src/opensdmx/cli.py
+++ b/src/opensdmx/cli.py
@@ -890,18 +890,84 @@ def which(
         )
 
 
+def _render_tree_block(
+    rows: Any,
+    root_label: str,
+    root_id: str,
+    render_root: str,
+    df_by_path: dict[str, list[dict[str, Any]]],
+) -> None:
+    """Print one ASCII category tree rooted at render_root ("" = whole scheme)."""
+    console.print(f"[bold]{root_label}[/bold] [dim]({root_id})[/dim]")
+
+    children: dict[str, list[dict[str, Any]]] = {}
+    for r in rows.iter_rows(named=True):
+        if render_root and r["cat_path"] == render_root:
+            continue
+        children.setdefault(r["parent_path"] or "", []).append(r)
+    for kids in children.values():
+        kids.sort(key=lambda x: x["cat_name"] or x["cat_id"])
+
+    def render(parent_path: str, prefix: str) -> None:
+        cats = children.get(parent_path, [])
+        dfs = df_by_path.get(parent_path, [])
+        total = len(cats) + len(dfs)
+        for i, node in enumerate(cats):
+            last = (i == total - 1)
+            branch = "└── " if last else "├── "
+            count_str = f" [dim]({node['n_df']} df)[/dim]" if node["n_df"] else ""
+            label = node["cat_name"] or node["cat_id"]
+            desc = node.get("cat_description") or ""
+            desc_str = f" [dim italic]— {desc}[/dim italic]" if desc and desc != label else ""
+            console.print(
+                f"{prefix}{branch}{label} [dim]\\[cat:{node['cat_id']}][/dim]{count_str}{desc_str}"
+            )
+            next_prefix = prefix + ("    " if last else "│   ")
+            render(node["cat_path"], next_prefix)
+        for j, d in enumerate(dfs):
+            last = (len(cats) + j) == total - 1
+            branch = "└── " if last else "├── "
+            label = d["df_description"] or d["df_id"]
+            console.print(f"{prefix}{branch}{label} [dim]\\[df:{d['df_id']}][/dim]")
+
+    render(render_root, "")
+
+
+def _category_rows(rows: Any) -> list[dict[str, Any]]:
+    """Flatten category rows for json/csv output."""
+    return [
+        {
+            "scheme_id": r["scheme_id"],
+            "cat_id": r["cat_id"],
+            "cat_path": r["cat_path"],
+            "cat_name": r["cat_name"] or "",
+            "cat_description": r.get("cat_description") or "",
+            "parent_path": r["parent_path"] or "",
+            "depth": int(r["depth"]),
+            "n_df": int(r["n_df"]),
+        }
+        for r in rows.iter_rows(named=True)
+    ]
+
+
 @app.command()
 def tree(
     scheme: Optional[str] = typer.Option(None, "--scheme", "-s", help="Render the tree for a specific scheme_id. If omitted, lists all schemes with dataflow counts."),
     category: Optional[str] = typer.Option(None, "--category", "-c", help="Restrict tree to the subtree rooted at this category ID (requires --scheme)."),
-    depth: Optional[int] = typer.Option(None, "--depth", "-d", help="Limit tree nesting depth (1 = only top-level)."),
-    show_dataflows: bool = typer.Option(False, "--show-dataflows", "-l", help="Inline dataflow leaves under each category (prefixed [df:ID])."),
+    depth: Optional[int] = typer.Option(None, "--depth", "-d", help="Levels to show below the current root (default: 1 without --scheme, unlimited with it)."),
+    show_dataflows: bool = typer.Option(False, "--show-dataflows", "-l", help="Inline dataflow leaves under each category (requires --scheme; prefixed [df:ID])."),
     provider: Optional[str] = typer.Option(None, "--provider", "-p", help=_PROVIDER_HELP),
     header: Optional[list[str]] = typer.Option(None, "--header", help="Extra HTTP header in 'Name: Value' format (repeatable)"),
 ) -> None:
     """Browse the thematic tree of dataflows (categoryscheme + categorisation).
 
-    Without --scheme: lists all schemes with their dataflow counts.
+    The provider is the root of the tree and the scheme list is level 1, so
+    --depth N always means "N levels below the current root".
+
+    Without --scheme: --depth 1 (the default) lists all schemes with their
+    dataflow counts; --depth 2 or more adds their categories, one tree per
+    scheme. --category and --show-dataflows are scheme-scoped and require
+    --scheme.
     With --scheme: renders an ASCII tree of that scheme's categories.
     With --scheme and --category: renders only the subtree under that category.
     With --show-dataflows: each category's dataflows appear inline as leaves
@@ -913,6 +979,7 @@ def tree(
     Examples:
 
       opensdmx tree --provider istat
+      opensdmx tree --depth 2 --provider istat
       opensdmx tree --scheme Z1000AGR --provider istat
       opensdmx tree --scheme Z0400PRI --category PRI_HARCONEU --provider istat
       opensdmx tree --scheme Z1000AGR --depth 2 --provider istat
@@ -943,6 +1010,38 @@ def tree(
     )
 
     if scheme is None:
+        if category is not None or show_dataflows:
+            bad = "--category" if category is not None else "--show-dataflows"
+            err_console.print(
+                f"[red]Error:[/red] {bad} requires --scheme.\n"
+                "Run [cyan]opensdmx tree[/cyan] to list the schemes, then pick one."
+            )
+            raise typer.Exit(1)
+
+        if depth is not None and depth >= 2:
+            # The provider is the root of the tree and the scheme list is level 1,
+            # so top-level categories (absolute depth 1) sit at depth 2.
+            all_rows = (
+                categories_df.filter(pl.col("depth") <= depth - 1)
+                .join(df_counts, on=["scheme_id", "cat_path"], how="left")
+                .with_columns(pl.col("n_df").fill_null(0))
+            )
+            if _output_mode != "table":
+                _emit(_category_rows(all_rows), df=all_rows)
+                return
+            for i, scheme_id in enumerate(sorted(all_rows["scheme_id"].unique().to_list())):
+                if i:
+                    console.print()
+                rows_s = all_rows.filter(pl.col("scheme_id") == scheme_id)
+                _render_tree_block(
+                    rows_s,
+                    rows_s.select("scheme_name").row(0)[0] or scheme_id,
+                    scheme_id,
+                    "",
+                    {},
+                )
+            return
+
         scheme_counts = (
             categorisation_df.group_by("scheme_id")
             .agg(pl.col("df_id").n_unique().alias("n_df"))
@@ -1096,44 +1195,15 @@ def tree(
     scheme_name = scheme_rows.select("scheme_name").row(0)[0] or scheme
     if category is not None:
         cat_root = scheme_rows.filter(pl.col("cat_id") == category).row(0, named=True)
-        root_label = cat_root["cat_name"] or category
-        console.print(f"[bold]{root_label}[/bold] [dim]({category})[/dim]")
-        render_root = cat_root["cat_path"]
+        _render_tree_block(
+            scheme_rows,
+            cat_root["cat_name"] or category,
+            category,
+            cat_root["cat_path"],
+            df_by_path,
+        )
     else:
-        console.print(f"[bold]{scheme_name}[/bold] [dim]({scheme})[/dim]")
-        render_root = ""
-
-    children: dict[str, list[dict[str, Any]]] = {}
-    for r in scheme_rows.iter_rows(named=True):
-        if category is not None and r["cat_path"] == render_root:
-            continue
-        children.setdefault(r["parent_path"] or "", []).append(r)
-    for kids in children.values():
-        kids.sort(key=lambda x: x["cat_name"] or x["cat_id"])
-
-    def render(parent_path: str, prefix: str) -> None:
-        cats = children.get(parent_path, [])
-        dfs = df_by_path.get(parent_path, [])
-        total = len(cats) + len(dfs)
-        for i, node in enumerate(cats):
-            last = (i == total - 1)
-            branch = "└── " if last else "├── "
-            count_str = f" [dim]({node['n_df']} df)[/dim]" if node["n_df"] else ""
-            label = node["cat_name"] or node["cat_id"]
-            desc = node.get("cat_description") or ""
-            desc_str = f" [dim italic]— {desc}[/dim italic]" if desc and desc != label else ""
-            console.print(
-                f"{prefix}{branch}{label} [dim]\\[cat:{node['cat_id']}][/dim]{count_str}{desc_str}"
-            )
-            next_prefix = prefix + ("    " if last else "│   ")
-            render(node["cat_path"], next_prefix)
-        for j, d in enumerate(dfs):
-            last = (len(cats) + j) == total - 1
-            branch = "└── " if last else "├── "
-            label = d["df_description"] or d["df_id"]
-            console.print(f"{prefix}{branch}{label} [dim]\\[df:{d['df_id']}][/dim]")
-
-    render(render_root, "")
+        _render_tree_block(scheme_rows, scheme_name, scheme, "", df_by_path)
 
 
 @app.command()

--- a/src/opensdmx/cli.py
+++ b/src/opensdmx/cli.py
@@ -891,7 +891,7 @@ def which(
 
 
 def _render_tree_block(
-    rows: Any,
+    rows: pl.DataFrame,
     root_label: str,
     root_id: str,
     render_root: str,
@@ -933,7 +933,7 @@ def _render_tree_block(
     render(render_root, "")
 
 
-def _category_rows(rows: Any) -> list[dict[str, Any]]:
+def _category_rows(rows: pl.DataFrame) -> list[dict[str, Any]]:
     """Flatten category rows for json/csv output."""
     return [
         {

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -347,6 +348,82 @@ def test_tree_category_unknown_id():
     assert result.exit_code == 1
     combined = result.output + (result.stderr or "")
     assert "not found in scheme" in combined
+
+
+def _invoke_tree(*args):
+    with patch("opensdmx.cli._check_api_reachable"), \
+         patch("opensdmx.categories.load_categories", return_value=_fake_categories_dfs()):
+        return runner.invoke(app, ["tree", *args, "--provider", "istat"])
+
+
+def test_tree_scoped_flags_require_scheme():
+    """--category and --show-dataflows have no global meaning: refuse, don't ignore."""
+    for flag in (["--category", "CAT_A"], ["--show-dataflows"]):
+        result = _invoke_tree(*flag)
+        assert result.exit_code == 1
+        combined = result.output + (result.stderr or "")
+        assert "requires --scheme" in combined
+
+
+def test_tree_no_scheme_depth_1_is_the_default():
+    """The skill's entry command `tree --depth 1` must keep listing schemes."""
+    assert _invoke_tree("--depth", "1").output == _invoke_tree().output
+
+
+def test_tree_no_scheme_depth_2_shows_top_level_categories():
+    """The provider is the root, so schemes are level 1 and categories level 2."""
+    shallow = _invoke_tree("--depth", "1").output
+    deep = _invoke_tree("--depth", "2")
+    assert deep.exit_code == 0
+    assert "Cat A" in deep.output and "Cat A" not in shallow
+    assert "Cat A1" not in deep.output  # absolute depth 2 is one level too deep
+
+
+def _fake_two_scheme_dfs():
+    """Minimal two-scheme fixture: the no-scheme tree renders one block per scheme."""
+    import polars as pl
+
+    categories_df = pl.DataFrame(
+        {
+            "scheme_id": ["S1", "S2"],
+            "scheme_name": ["Scheme one", "Scheme two"],
+            "cat_id": ["CAT_A", "CAT_B"],
+            "cat_path": ["CAT_A", "CAT_B"],
+            "cat_name": ["Cat A", "Cat B"],
+            "cat_description": ["", ""],
+            "parent_path": ["", ""],
+            "depth": [1, 1],
+        },
+        schema_overrides={"depth": pl.Int32},
+    )
+    categorisation_df = pl.DataFrame(
+        {"df_id": ["DF_X"], "scheme_id": ["S1"], "cat_path": ["CAT_A"]}
+    )
+    return categories_df, categorisation_df
+
+
+def test_tree_no_scheme_depth_2_renders_one_tree_per_scheme():
+    """Every scheme gets its own block, blank-line separated."""
+    with patch("opensdmx.cli._check_api_reachable"), \
+         patch("opensdmx.categories.load_categories", return_value=_fake_two_scheme_dfs()):
+        result = runner.invoke(app, ["tree", "--depth", "2", "--provider", "istat"])
+    assert result.exit_code == 0
+    out = result.output
+    assert "Scheme one (S1)" in out and "Scheme two (S2)" in out
+    assert "Cat A" in out and "Cat B" in out
+    # schemes are sorted and separated by a blank line
+    assert out.index("(S1)") < out.index("(S2)")
+    assert "\n\nScheme two" in out
+
+
+def test_tree_no_scheme_depth_json_emits_category_rows():
+    """json at depth >= 2 must carry categories, not the three-column summary."""
+    with patch("opensdmx.cli._check_api_reachable"), \
+         patch("opensdmx.categories.load_categories", return_value=_fake_categories_dfs()):
+        result = runner.invoke(app, ["-o", "json", "tree", "--depth", "2", "--provider", "istat"])
+    assert result.exit_code == 0
+    rows = json.loads(result.output)
+    assert [r["cat_id"] for r in rows] == ["CAT_A"]
 
 
 # ── _parse_header ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

`tree` has two code paths. When `--scheme` is omitted, the scheme-list branch returned before any tree-shaping flag was read, so every such flag was accepted and silently discarded with exit code 0.

Verified on `--provider istat` before this change:

| command | expected | actual |
|---|---|---|
| `tree --depth 1` | scheme list | scheme list (correct by accident) |
| `tree --depth 2` | schemes + their categories | identical to `--depth 1`, 45 lines |
| `tree --category AGR_CRP` | error — help says "requires --scheme" | scheme list, exit 0 |
| `tree --show-dataflows` | dataflow leaves | scheme list, exit 0 |

With `--scheme` the flag worked correctly (`Z1000AGR`: depth 1 → 7 lines, depth 2 → 22, depth 3 → 31), so this was a missing-branch defect, not a depth-filter bug.

The defect is not "`--depth` is broken". It is **no tree-shaping flag should be accepted and thrown away in silence**.

## Design

**The provider is the root of the tree; the scheme list is level 1.** `--depth N` then always means "N levels below the current root", and the special case disappears.

- `--depth 1`, and the no-flag default, keep printing exactly the previous scheme table. This matters: `skills/sdmx-explorer` documents `tree --depth 1` (no `--scheme`) as the entry point of the guided workflow, so erroring there — the other obvious fix — would break the canonical first command.
- `--depth 2` renders one tree per scheme with its top-level categories; ISTAT goes from 45 to 314 lines.
- `--category` and `--show-dataflows` without `--scheme` now exit 1. They are genuinely scheme-scoped and have no global meaning.

So `--depth` **acts** and the truly scoped flags **refuse**. Deliberate, not an inconsistency.

Accepted trade-off: the rendering changes shape with depth — level 1 is the `n_df` table, level 2+ the ASCII tree. No row-count warning or threshold; whoever types `--depth 3` asked for the big tree.

## Breaking

`tree --category X` and `tree --show-dataflows` without `--scheme` go from exit 0 to exit 1. Nobody could have relied on a silently ignored flag, but the exit code does change.

## Verification

Live against the ISTAT and Eurostat catalogues, not only the mocked fixture:

| check | result |
|---|---|
| `tree --depth 1` (istat) | 45 lines, identical to before |
| `tree --depth 2` (istat) | 314 lines, one tree per scheme |
| `tree --category AGR_CRP` | exit 1, "requires --scheme" |
| `tree --show-dataflows` | exit 1, "requires --scheme" |
| `-o json tree --depth 2` | category rows; depth 1 keeps the scheme summary |
| `tree --depth 1` (eurostat) | unchanged |
| `tree --scheme Z1000AGR --category AGR_MEANS --depth 1` | unchanged |

5 new tests, suite 271 → 276. Includes a regression guard that no-scheme `--depth 1` output stays byte-identical to the no-flag output, and a dedicated two-scheme fixture covering the one-tree-per-scheme loop that the existing single-scheme fixture could not reach.

`ruff check src/` and `tests/test_cli.py` clean. The pre-existing F401 in `test_base.py`, `test_db_cache.py`, `test_hub.py` are untouched and unrelated.

## Docs

`tree` docstring, `--depth`/`--show-dataflows` help strings, and `skills/sdmx-explorer/SKILL.md` all state the root/level model. The `--depth` help now also records that the default is 1 only without `--scheme` and unlimited with it — long-standing behaviour that the previous wording mis-described.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
