### PR TITLE
feat(search): match the category name, not just the title

### DIFF
--- a/LOG.md
+++ b/LOG.md
@@ -1,5 +1,16 @@
 # LOG
 
+## 2026-07-20 - search matches the category context
+
+- feat(search): keyword search now also matches the **category name** a dataflow belongs to. ISTAT titles are often leaf labels — `Sesso`, `Età`, `Lazio` — and 1,622 of 4,879 dataflows (33%) share a title with another. `search "disoccupati mensili" --provider istat` went from 2 results to 6, the four new ones being the dataflows that actually hold the data.
+- feat(search): results print the category as context (`Disoccupati - dati mensili › Sesso, età`), suppressed when the title already contains it. `info` gained a `Category:` line. `-o json|csv` carry a separate `category` field, so a machine gets the parts and a human the composed line.
+- **Not ISTAT-specific.** The context comes from the category cache, and `categories_supported` holds for 9 of 14 providers. Eurostat `search "consumer prices"` went from 33 to 66 results. Providers without categories, and users who never ran `opensdmx tree`, keep the previous behaviour exactly — verified on IMF.
+- refactor: `_category_context_for_embed()` moved to `categories.category_context()`, gaining an `include_scheme` flag and a `cat_primary` column. Embeddings keep scheme+category as before; search uses the category alone, since a scheme like "Lavoro e retribuzioni" would match nearly everything under it. New shared `utils.compose_title()`.
+- **Rejected on measurement.** The issue proposed deriving a parent title from the ISTAT id pattern `{parent}_DF_{dsd}_{n}`. Measured first: on the 3,460 dataflows having both, the parent title **is** the category name in 51% of cases, and contained in it in another 4% — an ISTAT-specific id parser would have rebuilt data the catalogue already carries and already feeds to the embeddings. The 45% where the parent says something else, typically the vintage, stays uncovered and is documented in #52.
+- `--grep` deliberately still applies to title and ID only, so documented recipes return the same rows. `tree` and `siblings` are untouched: both already group by category, so a per-row prefix would be pure duplication.
+- test: 4 new cases, including a regression guard that an absent category cache leaves results byte-identical. Suite 276 → 280.
+- fix: `str.concat` → `str.join`, silencing a polars DeprecationWarning that the wider use of this code path made frequent.
+
 ## 2026-07-20 - v0.16.0 - tree: stop dropping flags silently
 
 - **BREAKING** fix(cli): `tree --category X` and `tree --show-dataflows` without `--scheme` now exit 1 instead of silently printing the scheme list with exit 0. The `scheme is None` branch returned before any tree-shaping flag was read, so three flags were accepted and discarded — `--category`'s own help text already claimed "requires --scheme", an intent never enforced.

--- a/skills/sdmx-explorer/SKILL.md
+++ b/skills/sdmx-explorer/SKILL.md
@@ -247,11 +247,30 @@ Search for dataflows:
 - **Other providers**: `opensdmx search "<keyword>" --provider <name>`
   (available: `oecd`, `ecb`, `worldbank`, `insee`, `bundesbank`, `abs`)
 
-`search` matches the dataset **title and ID**, by substring. That means a short
-keyword also matches longer words starting the same way — searching `comuni` on
-ISTAT also returns titles containing "comunitari" or "comunicazione". Use
-`--grep` (a case-insensitive regex applied to the results) to narrow it down
-without a shell pipe:
+`search` matches the dataset **title, ID and category name**, by substring.
+
+The category name matters on ISTAT, where many titles are leaf labels that mean
+nothing alone — `Sesso`, `Età`, `Lazio`, and 1,622 dataflows sharing a title
+with at least one other. Searching `disoccupati mensili` returns the dataflows
+titled `Sesso, età` that hold the actual data, and prints them with their
+context so they can be told apart:
+
+```
+Disoccupati - dati mensili › Sesso, età
+Disoccupati - dati mensili - regolamento precedente (fino al 2020) › Sesso, età
+```
+
+The context comes from the local category cache, so **`opensdmx tree` makes
+search smarter**: run it once per provider and the categories become searchable.
+Without that cache — or on a provider with no categories — search behaves
+exactly as before. A category match ranks below a match on the dataflow's own
+title.
+
+Substring matching means a short keyword also matches longer words starting the
+same way: searching `comuni` on ISTAT also returns titles containing
+"comunitari" or "comunicazione". Use `--grep` (a case-insensitive regex applied
+to the results) to narrow it down without a shell pipe. Note `--grep` applies to
+title and ID only, never to the category, so these recipes stay precise:
 
 ```bash
 # whole word only — drops "comunitari", "comunicazione"

--- a/src/opensdmx/categories.py
+++ b/src/opensdmx/categories.py
@@ -359,3 +359,60 @@ def filter_by_category(cat_id_or_path: str) -> pl.DataFrame:
         logger.warning(f"Could not load dataflow list: {e}; returning category ids only")
         return matched
     return dataflows.join(matched, on="df_id", how="inner")
+
+
+def category_context(*, include_scheme: bool = True) -> pl.DataFrame:
+    """Aggregate the category names a dataflow belongs to, one row per df_id.
+
+    Returns columns: df_id, cat_context, cat_primary. A dataflow can sit in
+    several categories: `cat_context` concatenates them all, for matching, while
+    `cat_primary` holds one — the first alphabetically, so the choice is stable
+    across runs — for display, where a concatenation would be unreadable.
+    Measured: 96% of ISTAT dataflows have a single category, Eurostat up to 5.
+
+    Only reads the local cache — never triggers a live fetch. When the cache is
+    absent (provider without categories, or `opensdmx tree` never run) the
+    result is empty, and callers fall back to their previous behaviour.
+
+    Args:
+        include_scheme: prepend the scheme name to each category name. Useful
+            for embeddings, where broad topical words help; unhelpful for
+            keyword search, where a scheme like "Lavoro e retribuzioni" would
+            match nearly everything under it.
+    """
+    empty = pl.DataFrame(
+        {"df_id": [], "cat_context": [], "cat_primary": []},
+        schema={"df_id": pl.Utf8, "cat_context": pl.Utf8, "cat_primary": pl.Utf8},
+    )
+
+    cats_path = _categories_cache_path()
+    csation_path = _categorisation_cache_path()
+    if not cats_path.exists() or not csation_path.exists():
+        return empty
+
+    categories_df = pl.read_parquet(cats_path)
+    categorisation_df = pl.read_parquet(csation_path)
+
+    if categorisation_df.is_empty():
+        return empty
+
+    parts = ["scheme_name", "cat_name"] if include_scheme else ["cat_name"]
+    return (
+        categorisation_df.join(
+            categories_df.select(["scheme_id", "scheme_name", "cat_path", "cat_name"]),
+            on=["scheme_id", "cat_path"],
+            how="left",
+        )
+        .with_columns(
+            pl.concat_str(
+                [pl.col(c).fill_null("") for c in parts],
+                separator=" ",
+            ).str.strip_chars().alias("ctx"),
+            pl.col("cat_name").fill_null("").str.strip_chars().alias("cat_only"),
+        )
+        .group_by("df_id")
+        .agg(
+            pl.col("ctx").str.join(" ").alias("cat_context"),
+            pl.col("cat_only").sort().first().alias("cat_primary"),
+        )
+    )

--- a/src/opensdmx/cli.py
+++ b/src/opensdmx/cli.py
@@ -411,6 +411,8 @@ def search(
             title = f"Search: {keyword} ({total})"
 
     if _output_mode != "table":
+        import polars as pl
+
         rows = [
             {
                 "df_id": r["df_id"],
@@ -420,7 +422,16 @@ def search(
             }
             for r in page_df.iter_rows(named=True)
         ]
-        _emit(rows)
+        # Keep the typed frame for CSV: falling back to `rows` would stringify
+        # score. The category column is materialised even without a cache, so
+        # the schema does not depend on whether `opensdmx tree` has been run.
+        csv_df = page_df
+        if "cat_primary" not in csv_df.columns:
+            csv_df = csv_df.with_columns(pl.lit("").alias("cat_primary"))
+        csv_df = csv_df.select(
+            ["df_id", "df_description", pl.col("cat_primary").fill_null("").alias("category"), "score"]
+        )
+        _emit(rows, df=csv_df)
         return
 
     table = Table(title=title, show_lines=False)

--- a/src/opensdmx/cli.py
+++ b/src/opensdmx/cli.py
@@ -22,6 +22,27 @@ from rich.panel import Panel
 from rich.table import Table
 
 from .base import get_base_url, get_provider, set_extra_headers
+from .utils import compose_title
+
+def _category_of(df_id: str) -> str:
+    """Primary category name for one dataflow, or '' when unavailable.
+
+    Reads the local cache only, so it stays silent for providers without
+    categories and for users who never ran `opensdmx tree`.
+    """
+    try:
+        import polars as pl
+
+        from .categories import category_context
+
+        context = category_context(include_scheme=False)
+        if context.is_empty():
+            return ""
+        row = context.filter(pl.col("df_id") == df_id)
+        return "" if row.is_empty() else (row.row(0, named=True)["cat_primary"] or "")
+    except Exception:
+        return ""
+
 
 def _parse_header(value: str) -> tuple[str, str]:
     """Parse 'Name: Value' into (name, value). Raises BadParameter if no colon."""
@@ -391,10 +412,15 @@ def search(
 
     if _output_mode != "table":
         rows = [
-            {"df_id": r["df_id"], "df_description": r["df_description"] or "", "score": r.get("score", 0)}
+            {
+                "df_id": r["df_id"],
+                "df_description": r["df_description"] or "",
+                "category": r.get("cat_primary") or "",
+                "score": r.get("score", 0),
+            }
             for r in page_df.iter_rows(named=True)
         ]
-        _emit(rows, df=page_df.select(["df_id", "df_description", "score"]))
+        _emit(rows)
         return
 
     table = Table(title=title, show_lines=False)
@@ -403,7 +429,11 @@ def search(
     table.add_column("score", style="dim")
 
     for row in page_df.iter_rows(named=True):
-        table.add_row(row["df_id"], row["df_description"] or "", str(row.get("score", "")))
+        table.add_row(
+            row["df_id"],
+            compose_title(row["df_description"], row.get("cat_primary")),
+            str(row.get("score", "")),
+        )
 
     console.print(table)
 
@@ -461,6 +491,7 @@ def info(
             "df_id": ds["df_id"],
             "version": ds["version"],
             "df_description": ds["df_description"],
+            "category": _category_of(ds["df_id"]),
             "df_structure_id": ds["df_structure_id"],
             "dimensions": dims,
         }
@@ -473,6 +504,11 @@ def info(
         f"ID:          {ds['df_id']}\n"
         f"Version:     {ds['version']}\n"
         f"Description: {ds['df_description']}\n"
+    )
+    _cat = _category_of(ds["df_id"])
+    if _cat:
+        meta += f"Category:    {_cat}\n"
+    meta += (
         f"Structure:   {ds['df_structure_id']}"
     )
     if _page_url:

--- a/src/opensdmx/discovery.py
+++ b/src/opensdmx/discovery.py
@@ -198,12 +198,15 @@ def _score_results(
       +2  token found in first 60 chars of df_description (topic tends to be upfront)
       +1  each occurrence of token in df_description
     """
+    has_context = "cat_context" in df.columns
+    columns = [*_SEARCH_COLUMNS, "cat_context"] if has_context else None
+
     score_expr = pl.lit(0)
     coverage_expr = pl.lit(0) if prioritize_coverage else None
     for token in tokens:
         t = token.lower()
         if coverage_expr is not None:
-            coverage_expr = coverage_expr + _token_match_expr(t).fill_null(False).cast(pl.Int32)
+            coverage_expr = coverage_expr + _token_match_expr(t, columns).cast(pl.Int32)
         score_expr = score_expr + (
             pl.col("df_id").str.to_lowercase().str.contains(t).cast(pl.Int32) * 3
         )
@@ -213,6 +216,13 @@ def _score_results(
         score_expr = score_expr + (
             pl.col("df_description").str.to_lowercase().str.count_matches(t)
         )
+        if has_context:
+            # Below every own-title signal: the category says what the dataset is
+            # about, not what this particular cut contains.
+            score_expr = score_expr + (
+                pl.col("cat_context").str.to_lowercase().str.contains(t)
+                .fill_null(False).cast(pl.Int32)
+            )
     scored = df.with_columns(score_expr.alias("score"))
     if coverage_expr is not None:
         return (
@@ -223,13 +233,41 @@ def _score_results(
     return scored.sort("score", descending=True)
 
 
-def _token_match_expr(token: str) -> pl.Expr:
-    """True where a token appears in df_description or df_id (case-insensitive)."""
-    token = token.lower()
-    return (
-        pl.col("df_description").str.to_lowercase().str.contains(token)
-        | pl.col("df_id").str.to_lowercase().str.contains(token)
+_SEARCH_COLUMNS = ["df_description", "df_id"]
+
+
+def _with_category_context(datasets: pl.DataFrame) -> pl.DataFrame:
+    """Attach the cached category names as a searchable column.
+
+    Returns the frame untouched when no category cache exists, so providers
+    without categories — and users who never ran `opensdmx tree` — keep the
+    previous behaviour rather than hitting the network or an error.
+    """
+    try:
+        from .categories import category_context
+
+        context = category_context(include_scheme=False)
+    except Exception as e:  # pragma: no cover - defensive, search must never die here
+        logger.debug(f"Category context unavailable, searching titles only: {e}")
+        return datasets
+    if context.is_empty():
+        return datasets
+    return datasets.join(context, on="df_id", how="left").with_columns(
+        pl.col("cat_context").fill_null("")
     )
+
+
+def _token_match_expr(token: str, columns: list[str] | None = None) -> pl.Expr:
+    """True where a token appears in any of the given columns (case-insensitive).
+
+    Defaults to df_description and df_id. Callers that joined extra searchable
+    text — currently the category context — pass the wider list.
+    """
+    token = token.lower()
+    expr = pl.lit(False)
+    for column in columns or _SEARCH_COLUMNS:
+        expr = expr | pl.col(column).str.to_lowercase().str.contains(token).fill_null(False)
+    return expr
 
 
 def search_dataset(keyword: str) -> pl.DataFrame:
@@ -240,14 +278,21 @@ def search_dataset(keyword: str) -> pl.DataFrame:
     token no longer wipes out the whole result set. Results are sorted by a
     synthetic relevance score (id match, start-of-description, occurrence count),
     which keeps datasets matching all tokens at the top of the OR fallback.
-    Returns columns: df_id, version, df_description, df_structure_id, score.
+    Tokens also match the name of the categories a dataflow belongs to, so a
+    leaf title such as "Sesso, età" is reachable through its topic. That context
+    comes from the local category cache, populated by `opensdmx tree`; without
+    it the search behaves exactly as it did before.
+
+    Returns columns: df_id, version, df_description, df_structure_id,
+    cat_context, score.
     """
-    datasets = all_available()
+    datasets = _with_category_context(all_available())
+    columns = [*_SEARCH_COLUMNS, "cat_context"] if "cat_context" in datasets.columns else None
     tokens = [re.escape(token) for token in keyword.lower().split()]
 
     and_expr = pl.lit(True)
     for token in tokens:
-        and_expr = and_expr & _token_match_expr(token)
+        and_expr = and_expr & _token_match_expr(token, columns)
     results = datasets.filter(and_expr)
 
     # Fallback: a single unmatched token must not wipe out the whole result set.
@@ -255,7 +300,7 @@ def search_dataset(keyword: str) -> pl.DataFrame:
     if used_or_fallback:
         or_expr = pl.lit(False)
         for token in tokens:
-            or_expr = or_expr | _token_match_expr(token)
+            or_expr = or_expr | _token_match_expr(token, columns)
         results = datasets.filter(or_expr)
 
     if results.is_empty():

--- a/src/opensdmx/discovery.py
+++ b/src/opensdmx/discovery.py
@@ -283,8 +283,10 @@ def search_dataset(keyword: str) -> pl.DataFrame:
     comes from the local category cache, populated by `opensdmx tree`; without
     it the search behaves exactly as it did before.
 
-    Returns columns: df_id, version, df_description, df_structure_id,
-    cat_context, score.
+    Returns columns: df_id, version, df_description, df_structure_id, score —
+    plus cat_context and cat_primary when the category cache exists. Those two
+    are conditional: callers must use `.get()` or check `df.columns` rather than
+    assume them.
     """
     datasets = _with_category_context(all_available())
     columns = [*_SEARCH_COLUMNS, "cat_context"] if "cat_context" in datasets.columns else None

--- a/src/opensdmx/embed.py
+++ b/src/opensdmx/embed.py
@@ -50,41 +50,12 @@ def _embed(texts: list[str]) -> np.ndarray:
 def _category_context_for_embed() -> pl.DataFrame:
     """Aggregate scheme_name + cat_name per df_id from the cached category tree.
 
-    Only uses the local cache — never triggers a live fetch. If the category
-    cache files are not yet present (provider doesn't support categories, or
-    user hasn't run `opensdmx tree` yet), returns an empty DataFrame and the
-    embedding falls back to df_id + description only.
+    Thin wrapper kept for clarity at the call site; the implementation lives in
+    ``categories.category_context`` because keyword search needs it too.
     """
-    empty = pl.DataFrame({"df_id": [], "cat_context": []}, schema={"df_id": pl.Utf8, "cat_context": pl.Utf8})
+    from .categories import category_context
 
-    from .categories import _categories_cache_path, _categorisation_cache_path
-
-    cats_path = _categories_cache_path()
-    csation_path = _categorisation_cache_path()
-    if not cats_path.exists() or not csation_path.exists():
-        return empty
-
-    categories_df = pl.read_parquet(cats_path)
-    categorisation_df = pl.read_parquet(csation_path)
-
-    if categorisation_df.is_empty():
-        return empty
-
-    return (
-        categorisation_df.join(
-            categories_df.select(["scheme_id", "scheme_name", "cat_path", "cat_name"]),
-            on=["scheme_id", "cat_path"],
-            how="left",
-        )
-        .with_columns(
-            pl.concat_str(
-                [pl.col("scheme_name").fill_null(""), pl.col("cat_name").fill_null("")],
-                separator=" ",
-            ).str.strip_chars().alias("ctx")
-        )
-        .group_by("df_id")
-        .agg(pl.col("ctx").str.concat(" ").alias("cat_context"))
-    )
+    return category_context(include_scheme=True)
 
 
 def build_embeddings(progress: bool = True) -> None:

--- a/src/opensdmx/utils.py
+++ b/src/opensdmx/utils.py
@@ -66,6 +66,29 @@ def get_name_by_lang(node: Any, lang: str = "en", ns: dict[str, str] | None = No
     return None
 
 
+TITLE_SEPARATOR = " › "
+
+
+def compose_title(description: str | None, category: str | None = None) -> str:
+    """Render a dataflow title with its category as context.
+
+    Many ISTAT titles are leaf labels — "Sesso", "Età", "Lazio" — that mean
+    nothing alone; 1,622 of them are shared by more than one dataflow. Prefixing
+    the category makes the row identifiable wherever it is printed.
+
+    Returns the description unchanged when there is no category, when the two
+    are equal, or when the description already contains the category — which is
+    common, since a title often repeats its parent's wording.
+    """
+    title = (description or "").strip()
+    context = (category or "").strip()
+    if not context or not title:
+        return title or context
+    if context.lower() in title.lower():
+        return title
+    return f"{context}{TITLE_SEPARATOR}{title}"
+
+
 def _get_code_label(codelist_id: str | None, code_value: str) -> str:
     """Return human-readable label for a single code from cache, or '' if not found."""
     if not codelist_id:

--- a/src/opensdmx/utils.py
+++ b/src/opensdmx/utils.py
@@ -76,15 +76,19 @@ def compose_title(description: str | None, category: str | None = None) -> str:
     nothing alone; 1,622 of them are shared by more than one dataflow. Prefixing
     the category makes the row identifiable wherever it is printed.
 
-    Returns the description unchanged when there is no category, when the two
-    are equal, or when the description already contains the category — which is
-    common, since a title often repeats its parent's wording.
+    Returns the description unchanged when there is no category, or when the
+    title already *starts with* the category — common on Eurostat, where the
+    category often is the title's prefix, and repeating it would read badly.
+
+    The check is a prefix match, not a substring one: category "Age" must not be
+    suppressed from the title "Average earnings". Casefolded rather than
+    lowercased, so non-ASCII titles compare correctly.
     """
     title = (description or "").strip()
     context = (category or "").strip()
     if not context or not title:
         return title or context
-    if context.lower() in title.lower():
+    if title.casefold().startswith(context.casefold()):
         return title
     return f"{context}{TITLE_SEPARATOR}{title}"
 

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -450,6 +450,56 @@ def _fake_catalog() -> pl.DataFrame:
     )
 
 
+def _fake_context(rows: dict[str, str] | None = None) -> pl.DataFrame:
+    """Category-context frame as category_context() returns it."""
+    rows = rows or {}
+    return pl.DataFrame(
+        {
+            "df_id": list(rows.keys()),
+            "cat_context": list(rows.values()),
+            "cat_primary": list(rows.values()),
+        },
+        schema={"df_id": pl.Utf8, "cat_context": pl.Utf8, "cat_primary": pl.Utf8},
+    )
+
+
+def _search_with_context(keyword: str, context: pl.DataFrame, catalog=None):
+    catalog = _fake_catalog() if catalog is None else catalog
+    with patch("opensdmx.discovery.all_available", return_value=catalog), \
+         patch("opensdmx.categories.category_context", return_value=context):
+        return search_dataset(keyword)
+
+
+def test_search_matches_category_context():
+    """A leaf title is reachable through the name of its category."""
+    res = _search_with_context("unemployment", _fake_context({"GDP": "Unemployment monthly"}))
+    assert "GDP" in res["df_id"].to_list()
+
+
+def test_search_ranks_own_title_above_category_match():
+    """Category context is weaker evidence than the dataflow's own title."""
+    res = _search_with_context("unemployment", _fake_context({"GDP": "Unemployment monthly"}))
+    rows = res.iter_rows(named=True)
+    scores = {r["df_id"]: r["score"] for r in rows}
+    assert scores["UNEMP"] > scores["GDP"]
+
+
+def test_search_without_category_cache_is_unchanged():
+    """Empty context frame → byte-identical behaviour to before the feature."""
+    with_ctx = _search_with_context("unemployment age", _fake_context())
+    with patch("opensdmx.discovery.all_available", return_value=_fake_catalog()), \
+         patch("opensdmx.categories.category_context", side_effect=FileNotFoundError):
+        broken = search_dataset("unemployment age")
+    assert with_ctx["df_id"].to_list() == ["UNEMP"]
+    assert broken["df_id"].to_list() == ["UNEMP"]
+
+
+def test_search_context_does_not_duplicate_rows():
+    """One row per dataflow even though a dataflow can sit in several categories."""
+    res = _search_with_context("births", _fake_context({"BIRTHS": "Population Demography"}))
+    assert res["df_id"].to_list().count("BIRTHS") == 1
+
+
 def test_search_and_match_all_tokens():
     """All tokens present → AND path returns the single matching row."""
     with patch("opensdmx.discovery.all_available", return_value=_fake_catalog()):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 from opensdmx.utils import (
+    compose_title,
     get_name_by_lang,
     make_url_key,
     xml_attr_safe,
@@ -119,3 +120,30 @@ def test_get_name_by_lang_no_names():
 )
 def test_make_url_key(filters, expected):
     assert make_url_key(filters) == expected
+
+
+# ── compose_title ────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "description,category,expected",
+    [
+        # a leaf title gains its context
+        ("Sesso, età", "Disoccupati - dati mensili", "Disoccupati - dati mensili › Sesso, età"),
+        # already prefixed by the category: no repetition
+        ("Consumer prices - annual", "Consumer prices", "Consumer prices - annual"),
+        # a category merely *contained* in the title must NOT be suppressed:
+        # "Age" inside "Average" is a coincidence, not context
+        ("Average earnings", "Age", "Age › Average earnings"),
+        # casefold, not lower: non-ASCII prefixes still compare
+        ("ÈTA e sesso", "Età", "Età › ÈTA e sesso"),
+        ("Età e sesso", "ETÀ", "Età e sesso"),
+        # degenerate inputs
+        ("Sesso, età", None, "Sesso, età"),
+        ("Sesso, età", "", "Sesso, età"),
+        ("", "Lavoro", "Lavoro"),
+        (None, None, ""),
+    ],
+)
+def test_compose_title(description, category, expected):
+    assert compose_title(description, category) == expected


### PR DESCRIPTION
Closes #52.

## Problem

Keyword search matched `df_description` and `df_id` only (`discovery.py:226-232`). ISTAT titles are frequently leaf labels — `Sesso`, `Età`, `Lazio` — and **1,622 of 4,879 dataflows (33%) share a title with at least one other**. The context that `tree` displays simply did not exist in `search`.

Before, on ISTAT:

```
$ opensdmx search "disoccupati mensili" --provider istat
  151_1177   Disoccupati - dati mensili - regolamento precedente (fino al 2020)   6
  151_877    Disoccupati - dati mensili                                           6
```

Two results, both container dataflows. The four dataflows that actually hold the data are titled `Sesso, età` and were unreachable.

## After

```
$ opensdmx search "disoccupati mensili" --provider istat
  151_1177                                   Disoccupazione › Disoccupati - dati mensili …      6
  151_877                                    Disoccupazione › Disoccupati - dati mensili        6
  151_1177_DF_DCCV_DISOCCUPTMENS1_UNT20202   … › Incidenza dei disoccupati sulla popolazione    5
  151_877_DF_DCCV_DISOCCUPTMENS1_2           … › Incidenza dei disoccupati sulla popolazione    5
  151_1177_DF_DCCV_DISOCCUPTMENS1_UNT20201   Disoccupati - dati mensili - regolamento
                                             precedente (fino al 2020) › Sesso, età             2
  151_877_DF_DCCV_DISOCCUPTMENS1_1           Disoccupati - dati mensili › Sesso, età            2
```

The two `Sesso, età` rows are now both **findable** and **distinguishable** — including the discontinued-in-2020 series, which is exactly the case #52 raised. Category matches score below own-title matches, so the previous top hits stay on top.

## Why not the parent title, as the issue proposed

The issue proposed deriving a parent title from the ISTAT id pattern `{parent}_DF_{dsd}_{n}`. Measuring first killed that design. On the 3,460 ISTAT dataflows having both a parent and a category:

| relation between parent title and category name | dataflows | share |
|---|---|---|
| identical | 1,777 | 51% |
| one contained in the other | 136 | 4% |
| genuinely different | 1,545 | 45% |

For over half the catalogue the parent title **is** the category name — data already cached and already fed to the embeddings (`embed.py:79-86`). An ISTAT-specific id parser would have rebuilt it.

Known gap, documented in #52: the 45% where the parent carries something else, typically the vintage. Two dataflows titled `Veneto` share the category `Regioni e comuni` and differ only by parent ("Anni 2002-2019" vs "Anni 1982-1991").

## Multi-provider

Not an ISTAT feature. `categories_supported` holds for **9 of 14** providers, and the behaviour is driven by data availability — no `portals.json` gate, no id parsing.

| provider | query | before | after |
|---|---|---|---|
| istat | `disoccupati mensili` | 2 | **6** |
| eurostat | `consumer prices` | 33 | **66** |
| imf (no categories) | `inflation` | 1 | 1, unchanged |

Degrades silently when the category cache is missing — that is a regression test, not just a claim.

## Surfaces

- `search` table: category prefix, suppressed when the title already contains it (common on Eurostat, where the category often *is* the title prefix)
- `search -o json|csv`: separate `category` field — machine gets the parts, human gets the composed line
- `info`: new `Category:` line
- **`--grep` deliberately unchanged** — still title and ID only, so documented recipes (SKILL.md) return the same rows byte for byte
- **`tree` and `siblings` untouched** — both already group by category (`cli.py:1260`), so a per-row prefix would be pure duplication

## Refactor

`_category_context_for_embed()` promoted to `categories.category_context()` with an `include_scheme` flag and a new `cat_primary` column. Embeddings keep scheme+category as before; search uses the category alone, since a scheme like "Lavoro e retribuzioni" would match nearly everything beneath it. New shared `utils.compose_title()`.

## Verification

`ruff` clean, `mypy` clean on the three touched modules, suite 276 → 280. The four new tests cover: a leaf title found through its category, category ranking below own title, **absent cache → byte-identical results**, and no row duplication for multi-category dataflows (Eurostat has dataflows in up to 5).

Also fixes a latent polars `DeprecationWarning` (`str.concat` → `str.join`) that this code path made frequent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
